### PR TITLE
Add Bartscore metric for summarization and fix LLM eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,17 @@
 If you only want to evaluate your summarization/translation model for yanolja, then the only thing you need is to follow this guide and get evaluation results. 
 
 ### Installation
-To evaluate your model, you should install bleurt first.
+To evaluate your model, you should install bleurt and BARTScore first.
 ```bash
 pip install --upgrade pip  # ensures that pip is current
 git clone https://github.com/google-research/bleurt.git
 pip install ./bleurt
+```
+
+The BARTScore repository below is pip installable version of BARTScore with MBart (for supporting korean and so on).
+```bash
+git clone https://github.com/Y-IAB/BARTScore
+pip install -e ./BARTScore
 ```
 
 After that, please install this repository.

--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -156,12 +156,14 @@ class TaskManager:
             else:
                 config = self._process_alias(config, group=group)
                 task_object = ConfigurableTask(config=config)
-            if group is not None:
-                task_object = (group, task_object)
 
             for k, v in self.task_config.items():
                 self.logger.info(f"Updating task config: {k} = {v}")
                 task_object.config[k] = v
+
+            if group is not None:
+                task_object = (group, task_object)
+
 
             return {task: task_object}
 

--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -28,7 +28,10 @@ class TaskManager:
 
         self.task_group_map = collections.defaultdict(list)
 
-        self.task_config = utils.simple_parse_args_string(task_config)
+        if task_config is not None:
+            self.task_config = utils.simple_parse_args_string(task_config)
+        else:
+            self.task_config = {}
 
     def initialize_tasks(self, include_path: Optional[str] = None):
         """Creates a dictionary of tasks index.

--- a/lm_eval/tasks/yanolja/metrics.py
+++ b/lm_eval/tasks/yanolja/metrics.py
@@ -153,5 +153,10 @@ def agg_llm_eval(items):
                  api_version=AZURE_API_VERSION,
                  azure_api_base=AZURE_ENDPOINT))
     response = eval_llm.evaluate(data, checks=[Evals.CRITIQUE_LANGUAGE])
-    print(response)
-    return response[0]["score_critique_language"]
+    # return sum([resp["score_critique_language"] for resp in response]) /len(response)
+    # uptrain 0.5.0 version has 4 type of scores, so gather them and average them
+    score_fluency = sum([resp["score_fluency"] for resp in response]) /len(response)
+    score_grammar = sum([resp["score_grammar"] for resp in response]) /len(response)
+    score_coherence = sum([resp["score_coherence"] for resp in response]) /len(response)
+    score_politeness = sum([resp["score_politeness"] for resp in response]) /len(response)
+    return (score_fluency + score_grammar + score_coherence + score_politeness) / 4 

--- a/lm_eval/tasks/yanolja/metrics.py
+++ b/lm_eval/tasks/yanolja/metrics.py
@@ -7,7 +7,7 @@ from comet import download_model, load_from_checkpoint
 from uptrain import CritiqueTone, EvalLLM, Evals, Settings
 from BARTScore.bart_score import BARTScorer
 
-AZURE_API_KEY = os.environ.get("AZURE_OPENAI_API_KEY")
+AZURE_API_KEY = os.environ.get("AZURE_API_KEY")
 AZURE_API_VERSION = os.environ.get("AZURE_API_VERSION")
 AZURE_ENDPOINT = os.environ.get("AZURE_ENDPOINT")
 
@@ -113,11 +113,19 @@ def agg_bartscore_src(items):
     predictions, sources, src_langs, tgt_langs = zip(*items)
     src_lang = src_langs[0]
     tgt_lang = tgt_langs[0]
+
+    # If other language is added, then 
+    lang_code_dict = {
+        "en": "en_XX",
+        "ko": "ko_KR",
+        "ja": "ja_XX",
+        "zh": "zh_CN"
+    }
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     bart_scorer = BARTScorer(device=device,
                              checkpoint='facebook/mbart-large-50',
-                             src_lang=src_lang,
-                             tgt_lang=tgt_lang)
+                             src_lang=lang_code_dict[src_lang],
+                             tgt_lang=lang_code_dict[tgt_lang])
     
     # Calculate probability of predictions when sources are given as context
     scores = bart_scorer.score(sources, predictions)

--- a/lm_eval/tasks/yanolja/summarization_template.yaml
+++ b/lm_eval/tasks/yanolja/summarization_template.yaml
@@ -21,9 +21,8 @@ metric_list:
     higher_is_better: true
 
 generation_kwargs:
+  max_gen_toks: 512
   until:
-    - "\n\n"
-    - "\n"
     - "<|im_end|>"
     - "</s>"
 metadata:

--- a/lm_eval/tasks/yanolja/summarization_template.yaml
+++ b/lm_eval/tasks/yanolja/summarization_template.yaml
@@ -5,7 +5,7 @@ doc_to_text: "A chat between a curious user and an artificial intelligence assis
 Human: 주어진 한국어 text를 요약해주세요.
 text: {{text}}
 Assistant: "
-doc_to_target: '{"reference": "{{summary}}", "source": "{{text}}", "target_lang": "ko"}'
+doc_to_target: '{"reference": "{{summary}}", "source": "{{text}}", "source_lang": "ko", "target_lang": "ko"}'
 metric_list:
   - metric: !function metrics.bleu
     aggregation: !function metrics.agg_bleu

--- a/lm_eval/tasks/yanolja/translation_template.yaml
+++ b/lm_eval/tasks/yanolja/translation_template.yaml
@@ -22,6 +22,10 @@ metric_list:
     aggregation: !function metrics.agg_bleurt
     higher_is_better: true
 
+generation_kwargs:
+  until:
+    - "<|im_end|>"
+    - "</s>"
 
 
 metadata:

--- a/lm_eval/tasks/yanolja/translation_template.yaml
+++ b/lm_eval/tasks/yanolja/translation_template.yaml
@@ -7,7 +7,7 @@ Korean: {{source}}
 Assistant: "
 
 
-doc_to_target: '{"reference": "{{target}}", "source": "{{source}}", "target_lang": "en"}'
+doc_to_target: '{"reference": "{{target}}", "source": "{{source}}", "source_lang": "ko", "target_lang": "en"}'
 metric_list:
   - metric: !function metrics.bleu
     aggregation: !function metrics.agg_bleu

--- a/lm_eval/tasks/yanolja/yanolja_review_ko-en.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_review_ko-en.yaml
@@ -23,8 +23,6 @@ metric_list:
 
 generation_kwargs:
   until:
-    - "\n\n"
-    - "\n"
     - "<|im_end|>"
     - "</s>"
 metadata:

--- a/lm_eval/tasks/yanolja/yanolja_review_ko-en.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_review_ko-en.yaml
@@ -11,7 +11,7 @@ doc_to_text: "A chat between a curious user and an artificial intelligence assis
 Human: 주어진 한국어 문장을 영어로 번역해주세요. 번역된 문장은 영어로 시작해야 합니다.
 Korean: {{source}}
 Assistant: "
-doc_to_target: '{"reference": "{{target}}", "source": "{{source}}", "target_lang": "en"}'
+doc_to_target: '{"reference": "{{target}}", "source": "{{source}}", "source_lang": "ko", "target_lang": "en"}'
 
 metric_list:
   - metric: !function metrics.cometkiwi22

--- a/lm_eval/tasks/yanolja/yanolja_review_summarization.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_review_summarization.yaml
@@ -21,9 +21,8 @@ metric_list:
     higher_is_better: true
 
 generation_kwargs:
+  max_gen_toks: 512
   until:
-    - "\n\n"
-    - "\n"
     - "<|im_end|>"
     - "</s>"
 metadata:

--- a/lm_eval/tasks/yanolja/yanolja_review_summarization.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_review_summarization.yaml
@@ -10,11 +10,11 @@ doc_to_text: "A chat between a curious user and an artificial intelligence assis
 Human: 주어진 한국어 text를 요약해주세요.
 text: {{text}}
 Assistant: "
-doc_to_target: '{"reference": "{{summary}}", "source": "{{text}}", "target_lang": "ko"}'
+doc_to_target: '{"reference": "{{summary}}", "source": "{{text}}", "source_lang": "ko", "target_lang": "ko"}'
 
 metric_list:
-  - metric: !function metrics.cometkiwi22
-    aggregation: !function metrics.agg_cometkiwi22
+  - metric: !function metrics.bartscore_src
+    aggregation: !function metrics.agg_bartscore_src
     higher_is_better: true
   - metric: !function metrics.llm_eval
     aggregation: !function metrics.agg_llm_eval

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "word2number",
     "more_itertools",
     "unbabel-comet",
-    "uptrain",
+    "uptrain==0.5.0",
     "bert_score"
 ]
 


### PR DESCRIPTION
1. Add Bartscore metric - this metrics calculates generation probability, and use (-1 x loss) as scores.
 * For summarization scenario, I calculate score between source text and summary text, so named as BARTScore-src
2. For uptrain>0.5.0, there is an issue for evaulating korean languages, so I roll back to 0.5.0 and refine score calculation according to its output.