### PR TITLE
Add fragma based model & add xcomet/wmt23-cometkiwi metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ git clone https://github.com/Y-IAB/lm-evaluation-harness
 cd lm-evaluation-harness
 pip install -e .[openai]
 ```
+### Prerequisite
+Before you use this repository, you need to set some environment variables. Please set your environment variables with your key and endpoints.
+```bash
+AZURE_OPENAI_API_KEY="..."
+export AZURE_API_VERSION="2023-12-01-preview"
+export AZURE_ENDPOINT ="....openai.azure.com"
+AVAILABLE_GPUS=0,1,2,3,4,5
+```
 
 ### Dataset Setting
 Before you evaluate your models, you need to download dataset first. Please downlaod dataset from the [link](https://drive.google.com/file/d/1-CWu5E96mo9ub_-UsEXnX2JpIU9onaHN/view?usp=sharing) and drop the JSONL dataset files into `lm_eval/tasks/yanolja/data`.

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ pip install -e .[openai]
 ### Prerequisite
 Before you use this repository, you need to set some environment variables. Please set your environment variables with your key and endpoints.
 ```bash
-AZURE_OPENAI_API_KEY="..."
+export AZURE_OPENAI_API_KEY="..."
 export AZURE_API_VERSION="2023-12-01-preview"
 export AZURE_ENDPOINT ="....openai.azure.com"
-AVAILABLE_GPUS=0,1,2,3,4,5
+export AVAILABLE_GPUS=0,1,2,3,4,5
 ```
 
 ### Dataset Setting

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ After that, please install this repository.
 ```bash
 git clone https://github.com/Y-IAB/lm-evaluation-harness
 cd lm-evaluation-harness
-pip install -e .
+pip install -e .[openai]
 ```
 
 ### Dataset Setting

--- a/lm_eval/models/__init__.py
+++ b/lm_eval/models/__init__.py
@@ -1,6 +1,7 @@
 from . import (
     anthropic_llms,
     dummy,
+    fragma,
     gguf,
     huggingface,
     mamba_lm,

--- a/lm_eval/models/fragma.py
+++ b/lm_eval/models/fragma.py
@@ -1,0 +1,64 @@
+import json
+from typing import List, Optional, Tuple, Union
+
+import requests
+from tqdm import tqdm
+
+from lm_eval.api.instance import Instance
+from lm_eval.api.model import LM
+from lm_eval.api.registry import register_model
+
+
+@register_model("fragma")
+class Fragma(LM):
+
+    def __init__(self,
+                 api_key: str,
+                 endpoint: str,
+                 batch_size: Optional[Union[int, str]] = 1):
+        super().__init__()
+
+        self.endpoint = endpoint
+        self.headers = {
+            "Authorization": api_key,
+            'Content-Type': 'application/json'
+        }
+
+        # don't know how to use it yet
+        self.batch_size = batch_size
+
+    def generate_until(self, reqs: list[Instance]) -> list[str]:
+        results = []
+
+        for request in tqdm(reqs):
+            # The first argument is the formatted doc_to_text text.
+            source_text = request.args[0]
+
+            data = {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": source_text
+                    }
+                ]
+            }
+
+            response = requests.post(self.endpoint,
+                                     headers=self.headers,
+                                     json=data)
+
+            if response.status_code != 200:
+                print(f"An error occurred while generating: {response.text}")
+                raise Exception(response.text)
+
+            result = response.json()
+            results.append(result['choices'][0]['message']["content"])
+
+        return results
+
+    def loglikelihood(self, reqs: list[Instance]) -> list[tuple[float, bool]]:
+        pass
+
+    def loglikelihood_rolling(
+            self, reqs: list[Instance]) -> list[tuple[float, bool]]:
+        pass

--- a/lm_eval/tasks/yanolja/metrics.py
+++ b/lm_eval/tasks/yanolja/metrics.py
@@ -90,13 +90,74 @@ def agg_cometkiwi22(items):
     model = load_from_checkpoint(model_path)
 
     model_output = model.predict(data,
-                                 batch_size=8,
-                                 gpus=torch.cuda.device_count())
+                                 batch_size=4,
+                                 gpus=1,
+                                 devices=[5])
 
     # Example output:
     # Prediction([('scores', [0.8676194548606873]), ('system_score', 0.8676194548606873)])
 
     return model_output[1]
+
+def cometkiwi23(predictions, references):
+    try:
+        prediction, source = predictions[0], json.loads(references[0])["source"]
+    except:
+        print(references[0])
+        raise ValueError()
+
+    return (prediction, source)
+
+def agg_cometkiwi23(items):
+    predictions, sources = zip(*items)
+
+    data = []
+    for prediction, source in zip(predictions, sources):
+        data.append({"src": source, "mt": prediction})
+
+    model_path = download_model("Unbabel/wmt23-cometkiwi-da-xl")
+    model = load_from_checkpoint(model_path)
+
+    model_output = model.predict(data,
+                                 batch_size=4,
+                                 gpus=1,
+                                 devices=[3])
+
+    # Example output:
+    # Prediction([('scores', [0.8676194548606873]), ('system_score', 0.8676194548606873)])
+
+    return model_output[1]
+
+
+def xcomet(predictions, references):
+    try:
+        prediction, source = predictions[0], json.loads(references[0])["source"]
+    except:
+        print(references[0])
+        raise ValueError()
+
+    return (prediction, source)
+
+def agg_xcomet(items):
+    predictions, sources = zip(*items)
+
+    data = []
+    for prediction, source in zip(predictions, sources):
+        data.append({"src": source, "mt": prediction})
+
+    model_path = download_model("Unbabel/XCOMET-XL")
+    model = load_from_checkpoint(model_path)
+
+    model_output = model.predict(data,
+                                 batch_size=4,
+                                 gpus=1,
+                                 devices=[4])
+
+    # Example output:
+    # Prediction([('scores', [0.8676194548606873]), ('system_score', 0.8676194548606873)])
+
+    return model_output[1]
+
 
 def bartscore_src(predictions, references):
     try:
@@ -121,7 +182,7 @@ def agg_bartscore_src(items):
         "ja": "ja_XX",
         "zh": "zh_CN"
     }
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:1" if torch.cuda.is_available() else "cpu")
     bart_scorer = BARTScorer(device=device,
                              checkpoint='facebook/mbart-large-50',
                              src_lang=lang_code_dict[src_lang],

--- a/lm_eval/tasks/yanolja/metrics.py
+++ b/lm_eval/tasks/yanolja/metrics.py
@@ -11,6 +11,32 @@ AZURE_OPENAI_API_KEY = os.environ.get("AZURE_OPENAI_API_KEY")
 AZURE_API_VERSION = os.environ.get("AZURE_API_VERSION")
 AZURE_ENDPOINT = os.environ.get("AZURE_ENDPOINT")
 
+# Get available gpus from environment variable (e.g. AVAILABLE_GPUS=0,1,2,3,4,5)
+AVAILABLE_GPUS = os.environ.get("AVAILABLE_GPUS")
+AVAILABLE_GPUS = AVAILABLE_GPUS.split(",")
+CURRENT_GPU_INDEX = 0
+
+if len(AVAILABLE_GPUS) != 1:
+    # First GPU is always allocated to bleurt (maybe because of Tensorflow)
+    AVAILABLE_GPUS = AVAILABLE_GPUS[1:]
+
+
+def bleurt(predictions, references):
+    prediction, reference = predictions[0], json.loads(
+        references[0])["reference"]
+    return (prediction, reference)
+
+def agg_bleurt(items):
+    global CURRENT_GPU_INDEX
+    global AVAILABLE_GPUS
+    bleurt_fn = evaluate.load("bleurt", module_type="metric",
+                              checkpoint="bleurt-large-512")
+
+    predictions, references = zip(*items)
+    output = bleurt_fn.compute(predictions=predictions,
+                         references=references)["scores"]
+    return sum(output) / len(output)
+
 
 def bleu(predictions, references):
     try:
@@ -48,26 +74,17 @@ def bertscore(predictions, references):
     return (prediction, reference, lang)
 
 def agg_bertscore(items):
+    global CURRENT_GPU_INDEX
+    global AVAILABLE_GPUS
+ 
     bs_fn = evaluate.load("bertscore")
     predictions, references, langs = zip(*items)
     output = bs_fn.compute(predictions=predictions,
                           references=references,
                           model_type="bert-base-multilingual-cased",
-                          lang=langs[0])["f1"]
-    return sum(output) / len(output)
-
-def bleurt(predictions, references):
-    prediction, reference = predictions[0], json.loads(
-        references[0])["reference"]
-    return (prediction, reference)
-
-def agg_bleurt(items):
-    bleurt_fn = evaluate.load("bleurt", module_type="metric",
-                              checkpoint="bleurt-large-512")
-
-    predictions, references = zip(*items)
-    output = bleurt_fn.compute(predictions=predictions,
-                         references=references)["scores"]
+                          lang=langs[0],
+                          device="cuda:" + AVAILABLE_GPUS[CURRENT_GPU_INDEX])["f1"]
+    CURRENT_GPU_INDEX = (CURRENT_GPU_INDEX + 1) % len(AVAILABLE_GPUS)
     return sum(output) / len(output)
 
 def cometkiwi22(predictions, references):
@@ -80,6 +97,9 @@ def cometkiwi22(predictions, references):
     return (prediction, source)
 
 def agg_cometkiwi22(items):
+    global CURRENT_GPU_INDEX
+    global AVAILABLE_GPUS
+ 
     predictions, sources = zip(*items)
 
     data = []
@@ -92,7 +112,9 @@ def agg_cometkiwi22(items):
     model_output = model.predict(data,
                                  batch_size=4,
                                  gpus=1,
-                                 devices=[5])
+                                 devices=[int(AVAILABLE_GPUS[CURRENT_GPU_INDEX])])
+
+    CURRENT_GPU_INDEX = (CURRENT_GPU_INDEX + 1) % len(AVAILABLE_GPUS)
 
     # Example output:
     # Prediction([('scores', [0.8676194548606873]), ('system_score', 0.8676194548606873)])
@@ -109,6 +131,9 @@ def cometkiwi23(predictions, references):
     return (prediction, source)
 
 def agg_cometkiwi23(items):
+    global CURRENT_GPU_INDEX
+    global AVAILABLE_GPUS
+ 
     predictions, sources = zip(*items)
 
     data = []
@@ -121,7 +146,9 @@ def agg_cometkiwi23(items):
     model_output = model.predict(data,
                                  batch_size=4,
                                  gpus=1,
-                                 devices=[3])
+                                 devices=[int(AVAILABLE_GPUS[CURRENT_GPU_INDEX])])
+
+    CURRENT_GPU_INDEX = (CURRENT_GPU_INDEX + 1) % len(AVAILABLE_GPUS)
 
     # Example output:
     # Prediction([('scores', [0.8676194548606873]), ('system_score', 0.8676194548606873)])
@@ -139,6 +166,9 @@ def xcomet(predictions, references):
     return (prediction, source)
 
 def agg_xcomet(items):
+    global CURRENT_GPU_INDEX
+    global AVAILABLE_GPUS
+ 
     predictions, sources = zip(*items)
 
     data = []
@@ -151,7 +181,9 @@ def agg_xcomet(items):
     model_output = model.predict(data,
                                  batch_size=4,
                                  gpus=1,
-                                 devices=[4])
+                                 devices=[int(AVAILABLE_GPUS[CURRENT_GPU_INDEX])])
+
+    CURRENT_GPU_INDEX = (CURRENT_GPU_INDEX + 1) % len(AVAILABLE_GPUS)
 
     # Example output:
     # Prediction([('scores', [0.8676194548606873]), ('system_score', 0.8676194548606873)])
@@ -171,6 +203,9 @@ def bartscore_src(predictions, references):
     return (prediction, source, src_lang, tgt_lang)
 
 def agg_bartscore_src(items):
+    global CURRENT_GPU_INDEX
+    global AVAILABLE_GPUS
+ 
     predictions, sources, src_langs, tgt_langs = zip(*items)
     src_lang = src_langs[0]
     tgt_lang = tgt_langs[0]
@@ -182,7 +217,8 @@ def agg_bartscore_src(items):
         "ja": "ja_XX",
         "zh": "zh_CN"
     }
-    device = torch.device("cuda:1" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:" + AVAILABLE_GPUS[CURRENT_GPU_INDEX] if torch.cuda.is_available() else "cpu")
+    CURRENT_GPU_INDEX = (CURRENT_GPU_INDEX + 1) % len(AVAILABLE_GPUS)
     bart_scorer = BARTScorer(device=device,
                              checkpoint='facebook/mbart-large-50',
                              src_lang=lang_code_dict[src_lang],

--- a/lm_eval/tasks/yanolja/yanolja_review_ko-en.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_review_ko-en.yaml
@@ -17,6 +17,12 @@ metric_list:
   - metric: !function metrics.cometkiwi22
     aggregation: !function metrics.agg_cometkiwi22
     higher_is_better: true
+  - metric: !function metrics.cometkiwi23
+    aggregation: !function metrics.agg_cometkiwi23
+    higher_is_better: true
+  - metric: !function metrics.xcomet
+    aggregation: !function metrics.agg_xcomet
+    higher_is_better: true
   - metric: !function metrics.llm_eval
     aggregation: !function metrics.agg_llm_eval
     higher_is_better: true


### PR DESCRIPTION
1. Add fragma API based model for chat-completion (currently, for gemini model). However, it is not tested because our server can't access to fragma API 😢 .
2. Add xcomet / cometkiwi23 metrics for reference-free translation evaluation. It is almost similar with cometkiwi22, but with another pretrained model. 

CAUTION: Because this repository uses various model-based metrics, you need to allocate cuda device for Bartscore/cometkiwi/xcomet for yourself!