### PR TITLE
Add new task groups for low-cost evaluation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ The table shows the task groups we prepared in advance and their descriptions:
 
 |Task Name|Description|
 |---|---|
-|yanolja_summarization|This task group consists of various open-source summarization benchmarks (labeled) and real user input datasets from the yanolja reviewize service (unlabeled). The former are evaluated with reference-based metrics (BLEU, ROUGE, BLEURT, etc.), while the latter are evaluated with reference-free metrics (COMETKIWI, LLM Eval).|
-|yanolja_translation|This task group consists of various open-source translation benchmarks (labeled) and real user input datasets from the yanolja babel service (unlabeled). The former are evaluated with reference-based metrics (BLEU, ROUGE, BLEURT, etc.), while the latter are evaluated with reference-free metrics (COMETKIWI, LLM Eval). Both direction (ko-en, en-ko) are supported.|
-|yanolja_translation_handmade|This task group consists of human-labeled translations for travel domain. Because this task group is the most important for our task, we evaluate this group with all of metrics. Both direction (ko-en, en-ko) are supported.|
+|yanolja_summarization(`yasum`, `yasum_s`)|This task group consists of various open-source summarization benchmarks (labeled) and real user input datasets from the yanolja reviewize service (unlabeled). The former are evaluated with reference-based metrics (BLEU, ROUGE, BLEURT, etc.), while the latter are evaluated with reference-free metrics (COMETKIWI, LLM Eval).|
+|yanolja_translation(`yatrans`, `yatrans_s`)|This task group consists of various open-source translation benchmarks (labeled) and real user input datasets from the yanolja babel service (unlabeled). The former are evaluated with reference-based metrics (BLEU, ROUGE, BLEURT, etc.), while the latter are evaluated with reference-free metrics (COMETKIWI, LLM Eval). Both direction (ko-en, en-ko) are supported.|
+|yanolja_translation_handmade(`yatrans_hm`, `yatrans_hm_s`)|This task group consists of human-labeled translations for travel domain. Because this task group is the most important for our task, we evaluate this group with all of metrics. Both direction (ko-en, en-ko) are supported.|
 |yanolja_perplexity|This task group measures the perplexity of LLM on yonolja real English/Korean data. By doing so, we determine the similarity between LLM's knowledge and yanolja data domain.|
 
 ### Available Models

--- a/lm_eval/tasks/yanolja/summarization_template.yaml
+++ b/lm_eval/tasks/yanolja/summarization_template.yaml
@@ -1,4 +1,8 @@
-group: yanolja_summarization
+group: 
+  - yanolja_summarization
+  - yasum
+  - yanolja_summarization_simple
+  - yasum_s
 output_type: generate_until
 test_split: train
 doc_to_text: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful and concise answers to the user's questions.

--- a/lm_eval/tasks/yanolja/translation_template_en-ko.yaml
+++ b/lm_eval/tasks/yanolja/translation_template_en-ko.yaml
@@ -1,5 +1,10 @@
 # This template reverse ko-en template.
-group: yanolja_translation_en-ko
+group: 
+  - yanolja_translation_en-ko
+  - yatrans_en-ko
+  - yanolja_translation_simple_en-ko
+  - yatrans_s_en-ko
+
 output_type: generate_until
 test_split: train
 doc_to_text: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful and concise answers to the user's questions.

--- a/lm_eval/tasks/yanolja/yanolja_inbound_en-ko.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_inbound_en-ko.yaml
@@ -5,7 +5,9 @@ dataset_path: json
 dataset_kwargs:
   data_files: ./data/yanolja_inbound_ko-en.jsonl
 
-group: yanolja_translation_handmade_en-ko
+group: 
+  - yanolja_translation_handmade_en-ko
+  - yatrans_hm_en-ko
 output_type: generate_until
 test_split: train
 doc_to_text: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful and concise answers to the user's questions.

--- a/lm_eval/tasks/yanolja/yanolja_inbound_ja-ko.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_inbound_ja-ko.yaml
@@ -1,0 +1,48 @@
+# This file targets to another dataset because there is no references in dataset, so source and target is exactly same.
+task: yanolja_inbound_ja-ko
+dataset_name: yanolja_inbound_ja-ko
+dataset_path: json
+dataset_kwargs:
+  data_files: ./data/yanolja_inbound_ko-ja.jsonl
+
+group: yanolja_translation_handmade_ja-ko
+output_type: generate_until
+test_split: train
+doc_to_text: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful and concise answers to the user's questions.
+Human: 주어진 일본어 문장을 한국어로 번역해주세요. 번역된 문장은 한국어로 시작해야 합니다.
+Japanese: {{target}}
+Assistant: "
+doc_to_target: '{"reference": "{{source}}", "source": "{{target}}", "source_lang": "ja", "target_lang": "ko"}'
+
+metric_list:
+  - metric: !function metrics.bleu
+    aggregation: !function metrics.agg_bleu
+    higher_is_better: true
+  - metric: !function metrics.rouge
+    aggregation: !function metrics.agg_rouge
+    higher_is_better: true
+  - metric: !function metrics.bertscore
+    aggregation: !function metrics.agg_bertscore
+    higher_is_better: true
+  - metric: !function metrics.bleurt
+    aggregation: !function metrics.agg_bleurt
+    higher_is_better: true
+  - metric: !function metrics.cometkiwi22
+    aggregation: !function metrics.agg_cometkiwi22
+    higher_is_better: true
+  - metric: !function metrics.cometkiwi23
+    aggregation: !function metrics.agg_cometkiwi23
+    higher_is_better: true
+  - metric: !function metrics.xcomet
+    aggregation: !function metrics.agg_xcomet
+    higher_is_better: true
+  - metric: !function metrics.llm_eval
+    aggregation: !function metrics.agg_llm_eval
+    higher_is_better: true
+
+generation_kwargs:
+  until:
+    - "<|im_end|>"
+    - "</s>"
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/yanolja/yanolja_inbound_ja-ko.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_inbound_ja-ko.yaml
@@ -5,7 +5,9 @@ dataset_path: json
 dataset_kwargs:
   data_files: ./data/yanolja_inbound_ko-ja.jsonl
 
-group: yanolja_translation_handmade_ja-ko
+group: 
+  - yanolja_translation_handmade_ja-ko
+  - yatrans_hm_ja-ko
 output_type: generate_until
 test_split: train
 doc_to_text: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful and concise answers to the user's questions.

--- a/lm_eval/tasks/yanolja/yanolja_inbound_ko-en.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_inbound_ko-en.yaml
@@ -5,7 +5,9 @@ dataset_path: json
 dataset_kwargs:
   data_files: ./data/yanolja_inbound_ko-en.jsonl
 
-group: yanolja_translation_handmade_ko-en
+group: 
+  - yanolja_translation_handmade_ko-en
+  - yatrans_hm_ko-en
 output_type: generate_until
 test_split: train
 doc_to_text: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful and concise answers to the user's questions.

--- a/lm_eval/tasks/yanolja/yanolja_inbound_ko-ja.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_inbound_ko-ja.yaml
@@ -1,0 +1,48 @@
+# This file targets to another dataset because there is no references in dataset, so source and target is exactly same.
+task: yanolja_inbound_ko-ja
+dataset_name: yanolja_inbound_ko-ja
+dataset_path: json
+dataset_kwargs:
+  data_files: ./data/yanolja_inbound_ko-ja.jsonl
+
+group: yanolja_translation_handmade_ko-ja
+output_type: generate_until
+test_split: train
+doc_to_text: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful and concise answers to the user's questions.
+Human: 与えられた韓国語の文章を日本語に翻訳してください。 翻訳された文章は日本語で始まる必要があります。
+Korean: {{source}}
+Assistant: "
+doc_to_target: '{"reference": "{{target}}", "source": "{{source}}", "source_lang": "ko", "target_lang": "ja"}'
+
+metric_list:
+  - metric: !function metrics.bleu
+    aggregation: !function metrics.agg_bleu
+    higher_is_better: true
+  - metric: !function metrics.rouge
+    aggregation: !function metrics.agg_rouge
+    higher_is_better: true
+  - metric: !function metrics.bertscore
+    aggregation: !function metrics.agg_bertscore
+    higher_is_better: true
+  - metric: !function metrics.bleurt
+    aggregation: !function metrics.agg_bleurt
+    higher_is_better: true
+  - metric: !function metrics.cometkiwi22
+    aggregation: !function metrics.agg_cometkiwi22
+    higher_is_better: true
+  - metric: !function metrics.cometkiwi23
+    aggregation: !function metrics.agg_cometkiwi23
+    higher_is_better: true
+  - metric: !function metrics.xcomet
+    aggregation: !function metrics.agg_xcomet
+    higher_is_better: true
+  - metric: !function metrics.llm_eval
+    aggregation: !function metrics.agg_llm_eval
+    higher_is_better: true
+
+generation_kwargs:
+  until:
+    - "<|im_end|>"
+    - "</s>"
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/yanolja/yanolja_inbound_simple_en-ko.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_inbound_simple_en-ko.yaml
@@ -1,5 +1,5 @@
 # This file targets to another dataset because there is no references in dataset, so source and target is exactly same.
-task: yanolja_inbound_en-ko
+task: yanolja_inbound_simple_en-ko
 dataset_name: yanolja_inbound_en-ko
 dataset_path: json
 dataset_kwargs:

--- a/lm_eval/tasks/yanolja/yanolja_inbound_simple_en-ko.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_inbound_simple_en-ko.yaml
@@ -1,20 +1,20 @@
 # This file targets to another dataset because there is no references in dataset, so source and target is exactly same.
-task: yanolja_inbound_ko-ja
-dataset_name: yanolja_inbound_ko-ja
+task: yanolja_inbound_en-ko
+dataset_name: yanolja_inbound_en-ko
 dataset_path: json
 dataset_kwargs:
-  data_files: ./data/yanolja_inbound_ko-ja.jsonl
+  data_files: ./data/yanolja_inbound_ko-en.jsonl
 
 group: 
-  - yanolja_translation_handmade_ko-ja
-  - yatrans_hm_ko-ja
+  - yanolja_translation_handmade_simple_en-ko
+  - yatrans_hm_s_en-ko
 output_type: generate_until
 test_split: train
 doc_to_text: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful and concise answers to the user's questions.
-Human: 与えられた韓国語の文章を日本語に翻訳してください。 翻訳された文章は日本語で始まる必要があります。
-Korean: {{source}}
+Human: 주어진 영어 문장을 한국어로 번역해주세요. 번역된 문장은 한국어로 시작해야 합니다.
+English: {{target}}
 Assistant: "
-doc_to_target: '{"reference": "{{target}}", "source": "{{source}}", "source_lang": "ko", "target_lang": "ja"}'
+doc_to_target: '{"reference": "{{source}}", "source": "{{target}}", "source_lang": "en", "target_lang": "ko"}'
 
 metric_list:
   - metric: !function metrics.bleu
@@ -37,9 +37,6 @@ metric_list:
     higher_is_better: true
   - metric: !function metrics.xcomet
     aggregation: !function metrics.agg_xcomet
-    higher_is_better: true
-  - metric: !function metrics.llm_eval
-    aggregation: !function metrics.agg_llm_eval
     higher_is_better: true
 
 generation_kwargs:

--- a/lm_eval/tasks/yanolja/yanolja_inbound_simple_ja-ko.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_inbound_simple_ja-ko.yaml
@@ -1,5 +1,5 @@
 # This file targets to another dataset because there is no references in dataset, so source and target is exactly same.
-task: yanolja_inbound_ja-ko
+task: yanolja_inbound_simple_ja-ko
 dataset_name: yanolja_inbound_ja-ko
 dataset_path: json
 dataset_kwargs:

--- a/lm_eval/tasks/yanolja/yanolja_inbound_simple_ja-ko.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_inbound_simple_ja-ko.yaml
@@ -1,20 +1,20 @@
 # This file targets to another dataset because there is no references in dataset, so source and target is exactly same.
-task: yanolja_inbound_ko-ja
-dataset_name: yanolja_inbound_ko-ja
+task: yanolja_inbound_ja-ko
+dataset_name: yanolja_inbound_ja-ko
 dataset_path: json
 dataset_kwargs:
   data_files: ./data/yanolja_inbound_ko-ja.jsonl
 
 group: 
-  - yanolja_translation_handmade_ko-ja
-  - yatrans_hm_ko-ja
+  - yanolja_translation_handmade_simple_ja-ko
+  - yatrans_hm_s_ja-ko
 output_type: generate_until
 test_split: train
 doc_to_text: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful and concise answers to the user's questions.
-Human: 与えられた韓国語の文章を日本語に翻訳してください。 翻訳された文章は日本語で始まる必要があります。
-Korean: {{source}}
+Human: 주어진 일본어 문장을 한국어로 번역해주세요. 번역된 문장은 한국어로 시작해야 합니다.
+Japanese: {{target}}
 Assistant: "
-doc_to_target: '{"reference": "{{target}}", "source": "{{source}}", "source_lang": "ko", "target_lang": "ja"}'
+doc_to_target: '{"reference": "{{source}}", "source": "{{target}}", "source_lang": "ja", "target_lang": "ko"}'
 
 metric_list:
   - metric: !function metrics.bleu
@@ -37,9 +37,6 @@ metric_list:
     higher_is_better: true
   - metric: !function metrics.xcomet
     aggregation: !function metrics.agg_xcomet
-    higher_is_better: true
-  - metric: !function metrics.llm_eval
-    aggregation: !function metrics.agg_llm_eval
     higher_is_better: true
 
 generation_kwargs:

--- a/lm_eval/tasks/yanolja/yanolja_inbound_simple_ko-en.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_inbound_simple_ko-en.yaml
@@ -1,20 +1,20 @@
 # This file targets to another dataset because there is no references in dataset, so source and target is exactly same.
-task: yanolja_inbound_ko-ja
-dataset_name: yanolja_inbound_ko-ja
+task: yanolja_inbound_ko-en
+dataset_name: yanolja_inbound_ko-en
 dataset_path: json
 dataset_kwargs:
-  data_files: ./data/yanolja_inbound_ko-ja.jsonl
+  data_files: ./data/yanolja_inbound_ko-en.jsonl
 
 group: 
-  - yanolja_translation_handmade_ko-ja
-  - yatrans_hm_ko-ja
+  - yanolja_translation_handmade_simple_ko-en
+  - yatrans_hm_s_ko-en
 output_type: generate_until
 test_split: train
 doc_to_text: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful and concise answers to the user's questions.
-Human: 与えられた韓国語の文章を日本語に翻訳してください。 翻訳された文章は日本語で始まる必要があります。
+Human: 주어진 한국어 문장을 영어로 번역해주세요. 번역된 문장은 영어로 시작해야 합니다.
 Korean: {{source}}
 Assistant: "
-doc_to_target: '{"reference": "{{target}}", "source": "{{source}}", "source_lang": "ko", "target_lang": "ja"}'
+doc_to_target: '{"reference": "{{target}}", "source": "{{source}}", "source_lang": "ko", "target_lang": "en"}'
 
 metric_list:
   - metric: !function metrics.bleu
@@ -37,9 +37,6 @@ metric_list:
     higher_is_better: true
   - metric: !function metrics.xcomet
     aggregation: !function metrics.agg_xcomet
-    higher_is_better: true
-  - metric: !function metrics.llm_eval
-    aggregation: !function metrics.agg_llm_eval
     higher_is_better: true
 
 generation_kwargs:

--- a/lm_eval/tasks/yanolja/yanolja_inbound_simple_ko-en.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_inbound_simple_ko-en.yaml
@@ -1,5 +1,5 @@
 # This file targets to another dataset because there is no references in dataset, so source and target is exactly same.
-task: yanolja_inbound_ko-en
+task: yanolja_inbound_simple_ko-en
 dataset_name: yanolja_inbound_ko-en
 dataset_path: json
 dataset_kwargs:

--- a/lm_eval/tasks/yanolja/yanolja_inbound_simple_ko-ja.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_inbound_simple_ko-ja.yaml
@@ -6,8 +6,8 @@ dataset_kwargs:
   data_files: ./data/yanolja_inbound_ko-ja.jsonl
 
 group: 
-  - yanolja_translation_handmade_ko-ja
-  - yatrans_hm_ko-ja
+  - yanolja_translation_handmade_simple_ko-ja
+  - yatrans_hm_s_ko-ja
 output_type: generate_until
 test_split: train
 doc_to_text: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful and concise answers to the user's questions.
@@ -37,9 +37,6 @@ metric_list:
     higher_is_better: true
   - metric: !function metrics.xcomet
     aggregation: !function metrics.agg_xcomet
-    higher_is_better: true
-  - metric: !function metrics.llm_eval
-    aggregation: !function metrics.agg_llm_eval
     higher_is_better: true
 
 generation_kwargs:

--- a/lm_eval/tasks/yanolja/yanolja_inbound_simple_ko-ja.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_inbound_simple_ko-ja.yaml
@@ -1,5 +1,5 @@
 # This file targets to another dataset because there is no references in dataset, so source and target is exactly same.
-task: yanolja_inbound_ko-ja
+task: yanolja_inbound_simple_ko-ja
 dataset_name: yanolja_inbound_ko-ja
 dataset_path: json
 dataset_kwargs:

--- a/lm_eval/tasks/yanolja/yanolja_review_en-ko.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_review_en-ko.yaml
@@ -5,7 +5,9 @@ dataset_path: json
 dataset_kwargs:
   data_files: ./data/yanolja_review_en-ko.jsonl
 
-group: yanolja_translation_en-ko
+group: 
+  - yanolja_translation_en-ko
+  - yatrans_en-ko
 output_type: generate_until
 test_split: train
 doc_to_text: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful and concise answers to the user's questions.

--- a/lm_eval/tasks/yanolja/yanolja_review_simple_en-ko.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_review_simple_en-ko.yaml
@@ -1,5 +1,5 @@
 # This file targets to another dataset because there is no references in dataset, so source and target is exactly same.
-task: yanolja_review_en-ko
+task: yanolja_review_simple_en-ko
 dataset_name: yanolja_review_en-ko
 dataset_path: json
 dataset_kwargs:

--- a/lm_eval/tasks/yanolja/yanolja_review_simple_en-ko.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_review_simple_en-ko.yaml
@@ -1,19 +1,20 @@
-task: yanolja_review_ko-en
-dataset_name: yanolja_review_ko-en
+# This file targets to another dataset because there is no references in dataset, so source and target is exactly same.
+task: yanolja_review_en-ko
+dataset_name: yanolja_review_en-ko
 dataset_path: json
 dataset_kwargs:
-  data_files: ./data/yanolja_review_ko-en.jsonl
+  data_files: ./data/yanolja_review_en-ko.jsonl
 
 group: 
-  - yanolja_translation_ko-en
-  - yatrans_ko-en
+  - yanolja_translation_simple_en-ko
+  - yatrans_s_en-ko
 output_type: generate_until
 test_split: train
 doc_to_text: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful and concise answers to the user's questions.
-Human: 주어진 한국어 문장을 영어로 번역해주세요. 번역된 문장은 영어로 시작해야 합니다.
-Korean: {{source}}
+Human: 주어진 영어 문장을 한국어로 번역해주세요. 번역된 문장은 한국어로 시작해야 합니다.
+English: {{target}}
 Assistant: "
-doc_to_target: '{"reference": "{{target}}", "source": "{{source}}", "source_lang": "ko", "target_lang": "en"}'
+doc_to_target: '{"reference": "{{source}}", "source": "{{target}}", "source_lang": "en", "target_lang": "ko"}'
 
 metric_list:
   - metric: !function metrics.cometkiwi22
@@ -24,9 +25,6 @@ metric_list:
     higher_is_better: true
   - metric: !function metrics.xcomet
     aggregation: !function metrics.agg_xcomet
-    higher_is_better: true
-  - metric: !function metrics.llm_eval
-    aggregation: !function metrics.agg_llm_eval
     higher_is_better: true
 
 generation_kwargs:

--- a/lm_eval/tasks/yanolja/yanolja_review_simple_ko-en.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_review_simple_ko-en.yaml
@@ -1,4 +1,4 @@
-task: yanolja_review_ko-en
+task: yanolja_review_simple_ko-en
 dataset_name: yanolja_review_ko-en
 dataset_path: json
 dataset_kwargs:

--- a/lm_eval/tasks/yanolja/yanolja_review_simple_ko-en.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_review_simple_ko-en.yaml
@@ -1,37 +1,34 @@
+task: yanolja_review_ko-en
+dataset_name: yanolja_review_ko-en
+dataset_path: json
+dataset_kwargs:
+  data_files: ./data/yanolja_review_ko-en.jsonl
+
 group: 
-  - yanolja_translation_ko-en
-  - yatrans_ko-en
   - yanolja_translation_simple_ko-en
   - yatrans_s_ko-en
-
 output_type: generate_until
 test_split: train
 doc_to_text: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful and concise answers to the user's questions.
 Human: 주어진 한국어 문장을 영어로 번역해주세요. 번역된 문장은 영어로 시작해야 합니다.
 Korean: {{source}}
 Assistant: "
-
-
 doc_to_target: '{"reference": "{{target}}", "source": "{{source}}", "source_lang": "ko", "target_lang": "en"}'
+
 metric_list:
-  - metric: !function metrics.bleu
-    aggregation: !function metrics.agg_bleu
+  - metric: !function metrics.cometkiwi22
+    aggregation: !function metrics.agg_cometkiwi22
     higher_is_better: true
-  - metric: !function metrics.rouge
-    aggregation: !function metrics.agg_rouge
+  - metric: !function metrics.cometkiwi23
+    aggregation: !function metrics.agg_cometkiwi23
     higher_is_better: true
-  - metric: !function metrics.bertscore
-    aggregation: !function metrics.agg_bertscore
-    higher_is_better: true
-  - metric: !function metrics.bleurt
-    aggregation: !function metrics.agg_bleurt
+  - metric: !function metrics.xcomet
+    aggregation: !function metrics.agg_xcomet
     higher_is_better: true
 
 generation_kwargs:
   until:
     - "<|im_end|>"
     - "</s>"
-
-
 metadata:
   version: 1.0

--- a/lm_eval/tasks/yanolja/yanolja_review_summarization.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_review_summarization.yaml
@@ -15,6 +15,15 @@ Assistant: "
 doc_to_target: '{"reference": "{{summary}}", "source": "{{text}}", "source_lang": "ko", "target_lang": "ko"}'
 
 metric_list:
+  - metric: !function metrics.cometkiwi22
+    aggregation: !function metrics.agg_cometkiwi22
+    higher_is_better: true
+  - metric: !function metrics.cometkiwi23
+    aggregation: !function metrics.agg_cometkiwi23
+    higher_is_better: true
+  - metric: !function metrics.xcomet
+    aggregation: !function metrics.agg_xcomet
+    higher_is_better: true
   - metric: !function metrics.bartscore_src
     aggregation: !function metrics.agg_bartscore_src
     higher_is_better: true

--- a/lm_eval/tasks/yanolja/yanolja_review_summarization.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_review_summarization.yaml
@@ -3,7 +3,9 @@ dataset_name: yanolja_review_ko
 dataset_path: json
 dataset_kwargs:
   data_files: ./data/yanolja_review_summarization.jsonl
-group: yanolja_summarization
+group: 
+  - yanolja_summarization
+  - yasum
 output_type: generate_until
 test_split: train
 doc_to_text: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful and concise answers to the user's questions.

--- a/lm_eval/tasks/yanolja/yanolja_review_summarization_simple.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_review_summarization_simple.yaml
@@ -1,19 +1,18 @@
-task: yanolja_review_ko-en
-dataset_name: yanolja_review_ko-en
+task: yanolja_review_ko
+dataset_name: yanolja_review_ko
 dataset_path: json
 dataset_kwargs:
-  data_files: ./data/yanolja_review_ko-en.jsonl
-
+  data_files: ./data/yanolja_review_summarization.jsonl
 group: 
-  - yanolja_translation_ko-en
-  - yatrans_ko-en
+  - yanolja_summarization_simple
+  - yasum_s
 output_type: generate_until
 test_split: train
 doc_to_text: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful and concise answers to the user's questions.
-Human: 주어진 한국어 문장을 영어로 번역해주세요. 번역된 문장은 영어로 시작해야 합니다.
-Korean: {{source}}
+Human: 주어진 한국어 text를 요약해주세요.
+text: {{text}}
 Assistant: "
-doc_to_target: '{"reference": "{{target}}", "source": "{{source}}", "source_lang": "ko", "target_lang": "en"}'
+doc_to_target: '{"reference": "{{summary}}", "source": "{{text}}", "source_lang": "ko", "target_lang": "ko"}'
 
 metric_list:
   - metric: !function metrics.cometkiwi22
@@ -25,11 +24,12 @@ metric_list:
   - metric: !function metrics.xcomet
     aggregation: !function metrics.agg_xcomet
     higher_is_better: true
-  - metric: !function metrics.llm_eval
-    aggregation: !function metrics.agg_llm_eval
+  - metric: !function metrics.bartscore_src
+    aggregation: !function metrics.agg_bartscore_src
     higher_is_better: true
 
 generation_kwargs:
+  max_gen_toks: 512
   until:
     - "<|im_end|>"
     - "</s>"

--- a/lm_eval/tasks/yanolja/yanolja_review_summarization_simple.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_review_summarization_simple.yaml
@@ -1,4 +1,4 @@
-task: yanolja_review_ko
+task: yanolja_review_simple_ko
 dataset_name: yanolja_review_ko
 dataset_path: json
 dataset_kwargs:

--- a/lm_eval/tasks/yanolja/yanolja_triple_long_ja-ko.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_triple_long_ja-ko.yaml
@@ -5,7 +5,9 @@ dataset_path: json
 dataset_kwargs:
   data_files: ./data/yanolja_triple_long_ko-ja.jsonl
 
-group: yanolja_translation_handmade_ja-ko
+group: 
+  - yanolja_translation_handmade_ja-ko
+  - yatrans_hm_ja-ko
 output_type: generate_until
 test_split: train
 doc_to_text: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful and concise answers to the user's questions.

--- a/lm_eval/tasks/yanolja/yanolja_triple_long_ja-ko.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_triple_long_ja-ko.yaml
@@ -1,0 +1,48 @@
+# This file targets to another dataset because there is no references in dataset, so source and target is exactly same.
+task: yanolja_triple_long_ja-ko
+dataset_name: yanolja_triple_long_ja-ko
+dataset_path: json
+dataset_kwargs:
+  data_files: ./data/yanolja_triple_long_ko-ja.jsonl
+
+group: yanolja_translation_handmade_ja-ko
+output_type: generate_until
+test_split: train
+doc_to_text: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful and concise answers to the user's questions.
+Human: 주어진 일본어 문장을 한국어로 번역해주세요. 번역된 문장은 한국어로 시작해야 합니다.
+Japanese: {{target}}
+Assistant: "
+doc_to_target: '{"reference": "{{source}}", "source": "{{target}}", "source_lang": "ja", "target_lang": "ko"}'
+
+metric_list:
+  - metric: !function metrics.bleu
+    aggregation: !function metrics.agg_bleu
+    higher_is_better: true
+  - metric: !function metrics.rouge
+    aggregation: !function metrics.agg_rouge
+    higher_is_better: true
+  - metric: !function metrics.bertscore
+    aggregation: !function metrics.agg_bertscore
+    higher_is_better: true
+  - metric: !function metrics.bleurt
+    aggregation: !function metrics.agg_bleurt
+    higher_is_better: true
+  - metric: !function metrics.cometkiwi22
+    aggregation: !function metrics.agg_cometkiwi22
+    higher_is_better: true
+  - metric: !function metrics.cometkiwi23
+    aggregation: !function metrics.agg_cometkiwi23
+    higher_is_better: true
+  - metric: !function metrics.xcomet
+    aggregation: !function metrics.agg_xcomet
+    higher_is_better: true
+  - metric: !function metrics.llm_eval
+    aggregation: !function metrics.agg_llm_eval
+    higher_is_better: true
+
+generation_kwargs:
+  until:
+    - "<|im_end|>"
+    - "</s>"
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/yanolja/yanolja_triple_long_ko-ja.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_triple_long_ko-ja.yaml
@@ -1,0 +1,48 @@
+# This file targets to another dataset because there is no references in dataset, so source and target is exactly same.
+task: yanolja_triple_long_ko-ja
+dataset_name: yanolja_triple_long_ko-ja
+dataset_path: json
+dataset_kwargs:
+  data_files: ./data/yanolja_triple_long_ko-ja.jsonl
+
+group: yanolja_translation_handmade_ko-ja
+output_type: generate_until
+test_split: train
+doc_to_text: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful and concise answers to the user's questions.
+Human: 与えられた韓国語の文章を日本語に翻訳してください。 翻訳された文章は日本語で始まる必要があります。
+Korean: {{source}}
+Assistant: "
+doc_to_target: '{"reference": "{{target}}", "source": "{{source}}", "source_lang": "ko", "target_lang": "ja"}'
+
+metric_list:
+  - metric: !function metrics.bleu
+    aggregation: !function metrics.agg_bleu
+    higher_is_better: true
+  - metric: !function metrics.rouge
+    aggregation: !function metrics.agg_rouge
+    higher_is_better: true
+  - metric: !function metrics.bertscore
+    aggregation: !function metrics.agg_bertscore
+    higher_is_better: true
+  - metric: !function metrics.bleurt
+    aggregation: !function metrics.agg_bleurt
+    higher_is_better: true
+  - metric: !function metrics.cometkiwi22
+    aggregation: !function metrics.agg_cometkiwi22
+    higher_is_better: true
+  - metric: !function metrics.cometkiwi23
+    aggregation: !function metrics.agg_cometkiwi23
+    higher_is_better: true
+  - metric: !function metrics.xcomet
+    aggregation: !function metrics.agg_xcomet
+    higher_is_better: true
+  - metric: !function metrics.llm_eval
+    aggregation: !function metrics.agg_llm_eval
+    higher_is_better: true
+
+generation_kwargs:
+  until:
+    - "<|im_end|>"
+    - "</s>"
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/yanolja/yanolja_triple_long_ko-ja.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_triple_long_ko-ja.yaml
@@ -5,7 +5,9 @@ dataset_path: json
 dataset_kwargs:
   data_files: ./data/yanolja_triple_long_ko-ja.jsonl
 
-group: yanolja_translation_handmade_ko-ja
+group: 
+  - yanolja_translation_handmade_ko-ja
+  - yatrans_hm_ko-ja
 output_type: generate_until
 test_split: train
 doc_to_text: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful and concise answers to the user's questions.

--- a/lm_eval/tasks/yanolja/yanolja_triple_long_simple_ja-ko.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_triple_long_simple_ja-ko.yaml
@@ -1,5 +1,5 @@
 # This file targets to another dataset because there is no references in dataset, so source and target is exactly same.
-task: yanolja_triple_long_ja-ko
+task: yanolja_triple_long_simple_ja-ko
 dataset_name: yanolja_triple_long_ja-ko
 dataset_path: json
 dataset_kwargs:

--- a/lm_eval/tasks/yanolja/yanolja_triple_long_simple_ja-ko.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_triple_long_simple_ja-ko.yaml
@@ -1,20 +1,20 @@
 # This file targets to another dataset because there is no references in dataset, so source and target is exactly same.
-task: yanolja_inbound_ko-ja
-dataset_name: yanolja_inbound_ko-ja
+task: yanolja_triple_long_ja-ko
+dataset_name: yanolja_triple_long_ja-ko
 dataset_path: json
 dataset_kwargs:
-  data_files: ./data/yanolja_inbound_ko-ja.jsonl
+  data_files: ./data/yanolja_triple_long_ko-ja.jsonl
 
 group: 
-  - yanolja_translation_handmade_ko-ja
-  - yatrans_hm_ko-ja
+  - yanolja_translation_handmade_simple_ja-ko
+  - yatrans_hm_s_ja-ko
 output_type: generate_until
 test_split: train
 doc_to_text: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful and concise answers to the user's questions.
-Human: 与えられた韓国語の文章を日本語に翻訳してください。 翻訳された文章は日本語で始まる必要があります。
-Korean: {{source}}
+Human: 주어진 일본어 문장을 한국어로 번역해주세요. 번역된 문장은 한국어로 시작해야 합니다.
+Japanese: {{target}}
 Assistant: "
-doc_to_target: '{"reference": "{{target}}", "source": "{{source}}", "source_lang": "ko", "target_lang": "ja"}'
+doc_to_target: '{"reference": "{{source}}", "source": "{{target}}", "source_lang": "ja", "target_lang": "ko"}'
 
 metric_list:
   - metric: !function metrics.bleu
@@ -37,9 +37,6 @@ metric_list:
     higher_is_better: true
   - metric: !function metrics.xcomet
     aggregation: !function metrics.agg_xcomet
-    higher_is_better: true
-  - metric: !function metrics.llm_eval
-    aggregation: !function metrics.agg_llm_eval
     higher_is_better: true
 
 generation_kwargs:

--- a/lm_eval/tasks/yanolja/yanolja_triple_long_simple_ko-ja.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_triple_long_simple_ko-ja.yaml
@@ -1,5 +1,5 @@
 # This file targets to another dataset because there is no references in dataset, so source and target is exactly same.
-task: yanolja_triple_long_ko-ja
+task: yanolja_triple_long_simple_ko-ja
 dataset_name: yanolja_triple_long_ko-ja
 dataset_path: json
 dataset_kwargs:

--- a/lm_eval/tasks/yanolja/yanolja_triple_long_simple_ko-ja.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_triple_long_simple_ko-ja.yaml
@@ -1,13 +1,13 @@
 # This file targets to another dataset because there is no references in dataset, so source and target is exactly same.
-task: yanolja_inbound_ko-ja
-dataset_name: yanolja_inbound_ko-ja
+task: yanolja_triple_long_ko-ja
+dataset_name: yanolja_triple_long_ko-ja
 dataset_path: json
 dataset_kwargs:
-  data_files: ./data/yanolja_inbound_ko-ja.jsonl
+  data_files: ./data/yanolja_triple_long_ko-ja.jsonl
 
 group: 
-  - yanolja_translation_handmade_ko-ja
-  - yatrans_hm_ko-ja
+  - yanolja_translation_handmade_simple_ko-ja
+  - yatrans_hm_s_ko-ja
 output_type: generate_until
 test_split: train
 doc_to_text: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful and concise answers to the user's questions.
@@ -37,9 +37,6 @@ metric_list:
     higher_is_better: true
   - metric: !function metrics.xcomet
     aggregation: !function metrics.agg_xcomet
-    higher_is_better: true
-  - metric: !function metrics.llm_eval
-    aggregation: !function metrics.agg_llm_eval
     higher_is_better: true
 
 generation_kwargs:

--- a/lm_eval/tasks/yanolja/yanolja_triple_short_ja-ko.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_triple_short_ja-ko.yaml
@@ -5,7 +5,9 @@ dataset_path: json
 dataset_kwargs:
   data_files: ./data/yanolja_triple_short_ko-ja.jsonl
 
-group: yanolja_translation_handmade_ja-ko
+group: 
+  - yanolja_translation_handmade_ja-ko
+  - yatrans_hm_ja-ko
 output_type: generate_until
 test_split: train
 doc_to_text: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful and concise answers to the user's questions.

--- a/lm_eval/tasks/yanolja/yanolja_triple_short_ja-ko.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_triple_short_ja-ko.yaml
@@ -1,0 +1,48 @@
+# This file targets to another dataset because there is no references in dataset, so source and target is exactly same.
+task: yanolja_triple_short_ja-ko
+dataset_name: yanolja_triple_short_ja-ko
+dataset_path: json
+dataset_kwargs:
+  data_files: ./data/yanolja_triple_short_ko-ja.jsonl
+
+group: yanolja_translation_handmade_ja-ko
+output_type: generate_until
+test_split: train
+doc_to_text: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful and concise answers to the user's questions.
+Human: 주어진 일본어 문장을 한국어로 번역해주세요. 번역된 문장은 한국어로 시작해야 합니다.
+Japanese: {{target}}
+Assistant: "
+doc_to_target: '{"reference": "{{source}}", "source": "{{target}}", "source_lang": "ja", "target_lang": "ko"}'
+
+metric_list:
+  - metric: !function metrics.bleu
+    aggregation: !function metrics.agg_bleu
+    higher_is_better: true
+  - metric: !function metrics.rouge
+    aggregation: !function metrics.agg_rouge
+    higher_is_better: true
+  - metric: !function metrics.bertscore
+    aggregation: !function metrics.agg_bertscore
+    higher_is_better: true
+  - metric: !function metrics.bleurt
+    aggregation: !function metrics.agg_bleurt
+    higher_is_better: true
+  - metric: !function metrics.cometkiwi22
+    aggregation: !function metrics.agg_cometkiwi22
+    higher_is_better: true
+  - metric: !function metrics.cometkiwi23
+    aggregation: !function metrics.agg_cometkiwi23
+    higher_is_better: true
+  - metric: !function metrics.xcomet
+    aggregation: !function metrics.agg_xcomet
+    higher_is_better: true
+  - metric: !function metrics.llm_eval
+    aggregation: !function metrics.agg_llm_eval
+    higher_is_better: true
+
+generation_kwargs:
+  until:
+    - "<|im_end|>"
+    - "</s>"
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/yanolja/yanolja_triple_short_ko-ja.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_triple_short_ko-ja.yaml
@@ -5,7 +5,9 @@ dataset_path: json
 dataset_kwargs:
   data_files: ./data/yanolja_triple_short_ko-ja.jsonl
 
-group: yanolja_translation_handmade_ko-ja
+group: 
+  - yanolja_translation_handmade_ko-ja
+  - yatrans_hm_ko-ja
 output_type: generate_until
 test_split: train
 doc_to_text: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful and concise answers to the user's questions.

--- a/lm_eval/tasks/yanolja/yanolja_triple_short_ko-ja.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_triple_short_ko-ja.yaml
@@ -1,0 +1,48 @@
+# This file targets to another dataset because there is no references in dataset, so source and target is exactly same.
+task: yanolja_triple_short_ko-ja
+dataset_name: yanolja_triple_short_ko-ja
+dataset_path: json
+dataset_kwargs:
+  data_files: ./data/yanolja_triple_short_ko-ja.jsonl
+
+group: yanolja_translation_handmade_ko-ja
+output_type: generate_until
+test_split: train
+doc_to_text: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful and concise answers to the user's questions.
+Human: 与えられた韓国語の文章を日本語に翻訳してください。 翻訳された文章は日本語で始まる必要があります。
+Korean: {{source}}
+Assistant: "
+doc_to_target: '{"reference": "{{target}}", "source": "{{source}}", "source_lang": "ko", "target_lang": "ja"}'
+
+metric_list:
+  - metric: !function metrics.bleu
+    aggregation: !function metrics.agg_bleu
+    higher_is_better: true
+  - metric: !function metrics.rouge
+    aggregation: !function metrics.agg_rouge
+    higher_is_better: true
+  - metric: !function metrics.bertscore
+    aggregation: !function metrics.agg_bertscore
+    higher_is_better: true
+  - metric: !function metrics.bleurt
+    aggregation: !function metrics.agg_bleurt
+    higher_is_better: true
+  - metric: !function metrics.cometkiwi22
+    aggregation: !function metrics.agg_cometkiwi22
+    higher_is_better: true
+  - metric: !function metrics.cometkiwi23
+    aggregation: !function metrics.agg_cometkiwi23
+    higher_is_better: true
+  - metric: !function metrics.xcomet
+    aggregation: !function metrics.agg_xcomet
+    higher_is_better: true
+  - metric: !function metrics.llm_eval
+    aggregation: !function metrics.agg_llm_eval
+    higher_is_better: true
+
+generation_kwargs:
+  until:
+    - "<|im_end|>"
+    - "</s>"
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/yanolja/yanolja_triple_short_simple_ja-ko.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_triple_short_simple_ja-ko.yaml
@@ -1,5 +1,5 @@
 # This file targets to another dataset because there is no references in dataset, so source and target is exactly same.
-task: yanolja_triple_short_ja-ko
+task: yanolja_triple_short_simple_ja-ko
 dataset_name: yanolja_triple_short_ja-ko
 dataset_path: json
 dataset_kwargs:

--- a/lm_eval/tasks/yanolja/yanolja_triple_short_simple_ja-ko.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_triple_short_simple_ja-ko.yaml
@@ -1,20 +1,20 @@
 # This file targets to another dataset because there is no references in dataset, so source and target is exactly same.
-task: yanolja_inbound_ko-ja
-dataset_name: yanolja_inbound_ko-ja
+task: yanolja_triple_short_ja-ko
+dataset_name: yanolja_triple_short_ja-ko
 dataset_path: json
 dataset_kwargs:
-  data_files: ./data/yanolja_inbound_ko-ja.jsonl
+  data_files: ./data/yanolja_triple_short_ko-ja.jsonl
 
 group: 
-  - yanolja_translation_handmade_ko-ja
-  - yatrans_hm_ko-ja
+  - yanolja_translation_handmade_simple_ja-ko
+  - yatrans_hm_s_ja-ko
 output_type: generate_until
 test_split: train
 doc_to_text: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful and concise answers to the user's questions.
-Human: 与えられた韓国語の文章を日本語に翻訳してください。 翻訳された文章は日本語で始まる必要があります。
-Korean: {{source}}
+Human: 주어진 일본어 문장을 한국어로 번역해주세요. 번역된 문장은 한국어로 시작해야 합니다.
+Japanese: {{target}}
 Assistant: "
-doc_to_target: '{"reference": "{{target}}", "source": "{{source}}", "source_lang": "ko", "target_lang": "ja"}'
+doc_to_target: '{"reference": "{{source}}", "source": "{{target}}", "source_lang": "ja", "target_lang": "ko"}'
 
 metric_list:
   - metric: !function metrics.bleu
@@ -37,9 +37,6 @@ metric_list:
     higher_is_better: true
   - metric: !function metrics.xcomet
     aggregation: !function metrics.agg_xcomet
-    higher_is_better: true
-  - metric: !function metrics.llm_eval
-    aggregation: !function metrics.agg_llm_eval
     higher_is_better: true
 
 generation_kwargs:

--- a/lm_eval/tasks/yanolja/yanolja_triple_short_simple_ko-ja.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_triple_short_simple_ko-ja.yaml
@@ -1,13 +1,13 @@
 # This file targets to another dataset because there is no references in dataset, so source and target is exactly same.
-task: yanolja_inbound_ko-ja
-dataset_name: yanolja_inbound_ko-ja
+task: yanolja_triple_short_ko-ja
+dataset_name: yanolja_triple_short_ko-ja
 dataset_path: json
 dataset_kwargs:
-  data_files: ./data/yanolja_inbound_ko-ja.jsonl
+  data_files: ./data/yanolja_triple_short_ko-ja.jsonl
 
 group: 
-  - yanolja_translation_handmade_ko-ja
-  - yatrans_hm_ko-ja
+  - yanolja_translation_handmade_simple_ko-ja
+  - yatrans_hm_s_ko-ja
 output_type: generate_until
 test_split: train
 doc_to_text: "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful and concise answers to the user's questions.
@@ -38,10 +38,7 @@ metric_list:
   - metric: !function metrics.xcomet
     aggregation: !function metrics.agg_xcomet
     higher_is_better: true
-  - metric: !function metrics.llm_eval
-    aggregation: !function metrics.agg_llm_eval
-    higher_is_better: true
-
+    
 generation_kwargs:
   until:
     - "<|im_end|>"

--- a/lm_eval/tasks/yanolja/yanolja_triple_short_simple_ko-ja.yaml
+++ b/lm_eval/tasks/yanolja/yanolja_triple_short_simple_ko-ja.yaml
@@ -1,5 +1,5 @@
 # This file targets to another dataset because there is no references in dataset, so source and target is exactly same.
-task: yanolja_triple_short_ko-ja
+task: yanolja_triple_short_simple_ko-ja
 dataset_name: yanolja_triple_short_ko-ja
 dataset_path: json
 dataset_kwargs:


### PR DESCRIPTION
1. Simplify task name (because it becomes too long). The detail of task name is in README.
2. add simple evaluation group, which exclude llm-eval for cost & time eifficiency.