### PR TITLE
Add fragma chat completion

### DIFF
--- a/lm_eval/models/fragma.py
+++ b/lm_eval/models/fragma.py
@@ -54,7 +54,6 @@ class Fragma(LM):
 
                     result = response.json()
                     results.append(result['choices'][0]['message']["content"])
-                    attempts = 0
                     break
                 except Exception as e:
                     attempts += 1

--- a/lm_eval/models/fragma.py
+++ b/lm_eval/models/fragma.py
@@ -42,18 +42,30 @@ class Fragma(LM):
                     }
                 ]
             }
+            max_attempts = 10
+            attempts = 0
+            while attempts < max_attempts:
+                try:
+                    response = requests.post(self.endpoint,
+                                             headers=self.headers,
+                                             json=data)
 
-            response = requests.post(self.endpoint,
-                                     headers=self.headers,
-                                     json=data)
+                    if response.status_code != 200:
+                        print(f"An error occurred while generating: {response.text}")
+                        raise Exception(response.text)
 
-            if response.status_code != 200:
-                print(f"An error occurred while generating: {response.text}")
-                raise Exception(response.text)
+                    result = response.json()
+                    results.append(result['choices'][0]['message']["content"])
+                    attempts = 0
+                    break
+                except Exception as e:
+                    attempts += 1
+                    print("error occured. retrying...")
+                    continue
 
-            result = response.json()
-            results.append(result['choices'][0]['message']["content"])
-
+            if attempts == max_attempts:
+                print("maximum retries occured. Insert dummy result...")
+                results.append("dummy text")
         return results
 
     def loglikelihood(self, reqs: list[Instance]) -> list[tuple[float, bool]]:

--- a/lm_eval/models/fragma.py
+++ b/lm_eval/models/fragma.py
@@ -20,7 +20,7 @@ class Fragma(LM):
 
         self.endpoint = endpoint
         self.headers = {
-            "Authorization": api_key,
+            "api-key": api_key,
             'Content-Type': 'application/json'
         }
 

--- a/lm_eval/models/fragma.py
+++ b/lm_eval/models/fragma.py
@@ -50,9 +50,7 @@ class Fragma(LM):
                                              headers=self.headers,
                                              json=data)
 
-                    if response.status_code != 200:
-                        print(f"An error occurred while generating: {response.text}")
-                        raise Exception(response.text)
+                    response.raise_for_status()
 
                     result = response.json()
                     results.append(result['choices'][0]['message']["content"])
@@ -60,6 +58,7 @@ class Fragma(LM):
                     break
                 except Exception as e:
                     attempts += 1
+                    print(e)
                     print("error occured. retrying...")
                     continue
 

--- a/lm_eval/models/translators.py
+++ b/lm_eval/models/translators.py
@@ -51,10 +51,7 @@ class Translator(LM):
                     response = requests.post(self.endpoint,
                                              headers=self.headers,
                                              json=data)
-
-                    if response.status_code != 200:
-                        print(f"An error occurred while generating: {response.text}")
-                        raise Exception(response.text)
+                    response.raise_for_status()
 
                     result = response.json()
                     results.append(result['choices'][0]['message']["content"])
@@ -62,6 +59,7 @@ class Translator(LM):
                     break
                 except Exception as e:
                     attempts += 1
+                    print(e)
                     print("error occured. retrying...")
                     continue
 

--- a/lm_eval/models/translators.py
+++ b/lm_eval/models/translators.py
@@ -55,7 +55,6 @@ class Translator(LM):
 
                     result = response.json()
                     results.append(result['choices'][0]['message']["content"])
-                    attempts = 0
                     break
                 except Exception as e:
                     attempts += 1

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -71,7 +71,7 @@ def simple_parse_args_string(args_string):
         return {}
     arg_list = [arg for arg in args_string.split(",") if arg]
     args_dict = {
-        k: handle_arg_string(v) for k, v in [arg.split("=") for arg in arg_list]
+        k: handle_arg_string(v) for k, v in [arg.split("=", maxsplit=1) for arg in arg_list]
     }
     return args_dict
 

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -69,7 +69,10 @@ def simple_parse_args_string(args_string):
     args_string = args_string.strip()
     if not args_string:
         return {}
-    arg_list = [arg for arg in args_string.split(",") if arg]
+    if "doc_to_text" in args_string:
+        arg_list = [args_string]
+    else:
+        arg_list = [arg for arg in args_string.split(",") if arg]
     args_dict = {
         k: handle_arg_string(v) for k, v in [arg.split("=", maxsplit=1) for arg in arg_list]
     }


### PR DESCRIPTION
## Updates
1. fix ill-defined header for fragma chat completion 
2. Add retry loop for fragma chat completion and fragma translator
3. now we can use arguments that include "=" (ex. "endpoint=fragma.prod.in/openai/completion?model=gpt-35-turbo...")