### PR TITLE
[#25] Add Task List Metadata

### DIFF
--- a/lm_eval/models/fragma.py
+++ b/lm_eval/models/fragma.py
@@ -1,5 +1,5 @@
-import json
-from typing import List, Optional, Tuple, Union
+import os
+from typing import Optional, Union
 
 import requests
 from tqdm import tqdm
@@ -11,17 +11,16 @@ from lm_eval.api.registry import register_model
 
 @register_model("fragma")
 class Fragma(LM):
-
-    def __init__(self,
-                 api_key: str,
-                 endpoint: str,
-                 batch_size: Optional[Union[int, str]] = 1):
+    def __init__(
+        self, api_key: str, endpoint: str, batch_size: Optional[Union[int, str]] = 1
+    ):
         super().__init__()
 
+        env_api_key = os.environ.get("FRAGMA_API_KEY")
         self.endpoint = endpoint
         self.headers = {
-            "api-key": api_key,
-            'Content-Type': 'application/json'
+            "api-key": api_key or env_api_key,
+            "Content-Type": "application/json",
         }
 
         # don't know how to use it yet
@@ -34,41 +33,33 @@ class Fragma(LM):
             # The first argument is the formatted doc_to_text text.
             source_text = request.args[0]
 
-            data = {
-                "messages": [
-                    {
-                        "role": "user",
-                        "content": source_text
-                    }
-                ]
-            }
+            data = {"messages": [{"role": "user", "content": source_text}]}
             max_attempts = 10
             attempts = 0
             while attempts < max_attempts:
                 try:
-                    response = requests.post(self.endpoint,
-                                             headers=self.headers,
-                                             json=data)
+                    response = requests.post(
+                        self.endpoint, headers=self.headers, json=data
+                    )
 
                     response.raise_for_status()
 
                     result = response.json()
-                    results.append(result['choices'][0]['message']["content"])
+                    results.append(result["choices"][0]["message"]["content"])
                     break
                 except Exception as e:
                     attempts += 1
                     print(e)
-                    print("error occured. retrying...")
+                    print("error occurred. retrying...")
                     continue
 
             if attempts == max_attempts:
-                print("maximum retries occured. Insert dummy result...")
+                print("maximum retries occurred. Insert dummy result...")
                 results.append("dummy text")
         return results
 
     def loglikelihood(self, reqs: list[Instance]) -> list[tuple[float, bool]]:
         pass
 
-    def loglikelihood_rolling(
-            self, reqs: list[Instance]) -> list[tuple[float, bool]]:
+    def loglikelihood_rolling(self, reqs: list[Instance]) -> list[tuple[float, bool]]:
         pass

--- a/lm_eval/models/fragma.py
+++ b/lm_eval/models/fragma.py
@@ -1,5 +1,5 @@
-import os
-from typing import Optional, Union
+import json
+from typing import List, Optional, Tuple, Union
 
 import requests
 from tqdm import tqdm
@@ -11,16 +11,17 @@ from lm_eval.api.registry import register_model
 
 @register_model("fragma")
 class Fragma(LM):
-    def __init__(
-        self, api_key: str, endpoint: str, batch_size: Optional[Union[int, str]] = 1
-    ):
+
+    def __init__(self,
+                 api_key: str,
+                 endpoint: str,
+                 batch_size: Optional[Union[int, str]] = 1):
         super().__init__()
 
-        env_api_key = os.environ.get("FRAGMA_API_KEY")
         self.endpoint = endpoint
         self.headers = {
-            "api-key": api_key or env_api_key,
-            "Content-Type": "application/json",
+            "api-key": api_key,
+            'Content-Type': 'application/json'
         }
 
         # don't know how to use it yet
@@ -33,33 +34,41 @@ class Fragma(LM):
             # The first argument is the formatted doc_to_text text.
             source_text = request.args[0]
 
-            data = {"messages": [{"role": "user", "content": source_text}]}
+            data = {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": source_text
+                    }
+                ]
+            }
             max_attempts = 10
             attempts = 0
             while attempts < max_attempts:
                 try:
-                    response = requests.post(
-                        self.endpoint, headers=self.headers, json=data
-                    )
+                    response = requests.post(self.endpoint,
+                                             headers=self.headers,
+                                             json=data)
 
                     response.raise_for_status()
 
                     result = response.json()
-                    results.append(result["choices"][0]["message"]["content"])
+                    results.append(result['choices'][0]['message']["content"])
                     break
                 except Exception as e:
                     attempts += 1
                     print(e)
-                    print("error occurred. retrying...")
+                    print("error occured. retrying...")
                     continue
 
             if attempts == max_attempts:
-                print("maximum retries occurred. Insert dummy result...")
+                print("maximum retries occured. Insert dummy result...")
                 results.append("dummy text")
         return results
 
     def loglikelihood(self, reqs: list[Instance]) -> list[tuple[float, bool]]:
         pass
 
-    def loglikelihood_rolling(self, reqs: list[Instance]) -> list[tuple[float, bool]]:
+    def loglikelihood_rolling(
+            self, reqs: list[Instance]) -> list[tuple[float, bool]]:
         pass

--- a/lm_eval/tasks/metadata.yaml
+++ b/lm_eval/tasks/metadata.yaml
@@ -1,0 +1,2543 @@
+ammlu:
+  groups:
+  - ammlu
+  tasks:
+  - ammlu_high_school_chemistry
+  - ammlu_high_school_mathematics
+  - ammlu_human_aging
+  - ammlu_human_sexuality
+  - ammlu_high_school_statistics
+  - ammlu_management
+  - ammlu_moral_disputes
+  - ammlu_world_religions
+  - ammlu_philosophy
+  - ammlu_college_chemistry
+  - ammlu_high_school_physics
+  - ammlu_miscellaneous
+  - ammlu_computer_security
+  - ammlu_global_facts
+  - ammlu_college_mathematics
+  - ammlu_moral_scenarios
+  - ammlu_elementary_mathematics
+  - ammlu_professional_medicine
+  - ammlu_high_school_us_history
+  - ammlu_high_school_microeconomics
+  - ammlu_conceptual_physics
+  - ammlu_college_biology
+  - ammlu_abstract_algebra
+  - ammlu_security_studies
+  - ammlu_college_physics
+  - ammlu_virology
+  - ammlu_machine_learning
+  - ammlu_sociology
+  - ammlu_high_school_biology
+  - ammlu_medical_genetics
+  - ammlu_high_school_geography
+  - ammlu_professional_psychology
+  - ammlu_anatomy
+  - ammlu_nutrition
+  - ammlu_astronomy
+  - ammlu_business_ethics
+  - ammlu_college_medicine
+  - ammlu_clinical_knowledge
+  - ammlu_high_school_psychology
+  - ammlu_logical_fallacies
+  - ammlu_high_school_macroeconomics
+  - ammlu_public_relations
+  - ammlu_high_school_government_and_politics
+  - ammlu_econometrics
+  - ammlu_college_computer_science
+  - ammlu_formal_logic
+  - ammlu_high_school_computer_science
+  - ammlu_high_school_world_history
+  - ammlu_high_school_european_history
+  - ammlu_international_law
+  - ammlu_marketing
+  - ammlu_professional_law
+  - ammlu_jurisprudence
+  - ammlu_electrical_engineering
+  - ammlu_professional_accounting
+  - ammlu_us_foreign_policy
+  - ammlu_prehistory
+anli:
+  groups:
+  - anli
+  tasks:
+  - anli_r1
+  - anli_r2
+  - anli_r3
+arc:
+  groups:
+  - ai2_arc
+  tasks:
+  - arc_easy
+  - arc_challenge
+arithmetic:
+  groups:
+  - arithmetic
+  tasks:
+  - arithmetic_5da
+  - arithmetic_2dm
+  - arithmetic_5ds
+  - arithmetic_2ds
+  - arithmetic_1dc
+  - arithmetic_2da
+  - arithmetic_3da
+  - arithmetic_3ds
+  - arithmetic_4da
+  - arithmetic_4ds
+asdiv:
+  groups: []
+  tasks:
+  - asdiv
+babi:
+  groups: []
+  tasks:
+  - babi
+bbh/cot_fewshot:
+  groups:
+  - bbh
+  - bbh_cot_fewshot
+  tasks:
+  - bbh_cot_fewshot_logical_deduction_seven_objects
+  - bbh_cot_fewshot_formal_fallacies
+  - bbh_cot_fewshot_temporal_sequences
+  - bbh_cot_fewshot_penguins_in_a_table
+  - bbh_cot_fewshot_logical_deduction_five_objects
+  - bbh_cot_fewshot_boolean_expressions
+  - bbh_cot_fewshot_web_of_lies
+  - bbh_cot_fewshot_word_sorting
+  - bbh_cot_fewshot_disambiguation_qa
+  - bbh_cot_fewshot_navigate
+  - bbh_cot_fewshot_snarks
+  - bbh_cot_fewshot_tracking_shuffled_objects_three_objects
+  - bbh_cot_fewshot_ruin_names
+  - bbh_cot_fewshot_dyck_languages
+  - bbh_cot_fewshot_movie_recommendation
+  - bbh_cot_fewshot_causal_judgement
+  - bbh_cot_fewshot_tracking_shuffled_objects_five_objects
+  - bbh_cot_fewshot_hyperbaton
+  - bbh_cot_fewshot_multistep_arithmetic_two
+  - bbh_cot_fewshot_object_counting
+  - bbh_cot_fewshot_date_understanding
+  - bbh_cot_fewshot_logical_deduction_three_objects
+  - bbh_cot_fewshot_reasoning_about_colored_objects
+  - bbh_cot_fewshot_tracking_shuffled_objects_seven_objects
+  - bbh_cot_fewshot_salient_translation_error_detection
+  - bbh_cot_fewshot_geometric_shapes
+  - bbh_cot_fewshot_sports_understanding
+bbh/cot_zeroshot:
+  groups:
+  - bbh_cot_zeroshot
+  tasks:
+  - bbh_cot_zeroshot_boolean_expressions
+  - bbh_cot_zeroshot_formal_fallacies
+  - bbh_cot_zeroshot_logical_deduction_seven_objects
+  - bbh_cot_zeroshot_hyperbaton
+  - bbh_cot_zeroshot_word_sorting
+  - bbh_cot_zeroshot_disambiguation_qa
+  - bbh_cot_zeroshot_logical_deduction_five_objects
+  - bbh_cot_zeroshot_date_understanding
+  - bbh_cot_zeroshot_movie_recommendation
+  - bbh_cot_zeroshot_object_counting
+  - bbh_cot_zeroshot_dyck_languages
+  - bbh_cot_zeroshot_tracking_shuffled_objects_three_objects
+  - bbh_cot_zeroshot_tracking_shuffled_objects_five_objects
+  - bbh_cot_zeroshot_temporal_sequences
+  - bbh_cot_zeroshot_salient_translation_error_detection
+  - bbh_cot_zeroshot_ruin_names
+  - bbh_cot_zeroshot_geometric_shapes
+  - bbh_cot_zeroshot_causal_judgement
+  - bbh_cot_zeroshot_penguins_in_a_table
+  - bbh_cot_zeroshot_multistep_arithmetic_two
+  - bbh_cot_zeroshot_reasoning_about_colored_objects
+  - bbh_cot_zeroshot_web_of_lies
+  - bbh_cot_zeroshot_snarks
+  - bbh_cot_zeroshot_logical_deduction_three_objects
+  - bbh_cot_zeroshot_tracking_shuffled_objects_seven_objects
+  - bbh_cot_zeroshot_sports_understanding
+  - bbh_cot_zeroshot_navigate
+bbh/fewshot:
+  groups:
+  - bbh_fewshot
+  tasks:
+  - bbh_fewshot_ruin_names
+  - bbh_fewshot_date_understanding
+  - bbh_fewshot_causal_judgement
+  - bbh_fewshot_tracking_shuffled_objects_seven_objects
+  - bbh_fewshot_dyck_languages
+  - bbh_fewshot_snarks
+  - bbh_fewshot_logical_deduction_five_objects
+  - bbh_fewshot_penguins_in_a_table
+  - bbh_fewshot_reasoning_about_colored_objects
+  - bbh_fewshot_logical_deduction_three_objects
+  - bbh_fewshot_movie_recommendation
+  - bbh_fewshot_boolean_expressions
+  - bbh_fewshot_multistep_arithmetic_two
+  - bbh_fewshot_word_sorting
+  - bbh_fewshot_disambiguation_qa
+  - bbh_fewshot_tracking_shuffled_objects_five_objects
+  - bbh_fewshot_tracking_shuffled_objects_three_objects
+  - bbh_fewshot_geometric_shapes
+  - bbh_fewshot_sports_understanding
+  - bbh_fewshot_hyperbaton
+  - bbh_fewshot_formal_fallacies
+  - bbh_fewshot_navigate
+  - bbh_fewshot_object_counting
+  - bbh_fewshot_salient_translation_error_detection
+  - bbh_fewshot_temporal_sequences
+  - bbh_fewshot_web_of_lies
+  - bbh_fewshot_logical_deduction_seven_objects
+bbh/zeroshot:
+  groups:
+  - bbh_zeroshot
+  tasks:
+  - bbh_zeroshot_salient_translation_error_detection
+  - bbh_zeroshot_dyck_languages
+  - bbh_zeroshot_logical_deduction_three_objects
+  - bbh_zeroshot_penguins_in_a_table
+  - bbh_zeroshot_navigate
+  - bbh_zeroshot_logical_deduction_seven_objects
+  - bbh_zeroshot_formal_fallacies
+  - bbh_zeroshot_disambiguation_qa
+  - bbh_zeroshot_object_counting
+  - bbh_zeroshot_tracking_shuffled_objects_five_objects
+  - bbh_zeroshot_boolean_expressions
+  - bbh_zeroshot_movie_recommendation
+  - bbh_zeroshot_word_sorting
+  - bbh_zeroshot_geometric_shapes
+  - bbh_zeroshot_tracking_shuffled_objects_seven_objects
+  - bbh_zeroshot_sports_understanding
+  - bbh_zeroshot_multistep_arithmetic_two
+  - bbh_zeroshot_causal_judgement
+  - bbh_zeroshot_hyperbaton
+  - bbh_zeroshot_ruin_names
+  - bbh_zeroshot_temporal_sequences
+  - bbh_zeroshot_logical_deduction_five_objects
+  - bbh_zeroshot_reasoning_about_colored_objects
+  - bbh_zeroshot_web_of_lies
+  - bbh_zeroshot_snarks
+  - bbh_zeroshot_tracking_shuffled_objects_three_objects
+  - bbh_zeroshot_date_understanding
+belebele:
+  groups:
+  - belebele
+  tasks:
+  - belebele_khm_Khmr
+  - belebele_eng_Latn
+  - belebele_tur_Latn
+  - belebele_dan_Latn
+  - belebele_npi_Deva
+  - belebele_ita_Latn
+  - belebele_nya_Latn
+  - belebele_jpn_Jpan
+  - belebele_srp_Cyrl
+  - belebele_lao_Laoo
+  - belebele_sot_Latn
+  - belebele_nob_Latn
+  - belebele_pes_Arab
+  - belebele_tso_Latn
+  - belebele_ars_Arab
+  - belebele_als_Latn
+  - belebele_tgl_Latn
+  - belebele_plt_Latn
+  - belebele_kat_Geor
+  - belebele_ben_Latn
+  - belebele_eus_Latn
+  - belebele_pan_Guru
+  - belebele_amh_Ethi
+  - belebele_lvs_Latn
+  - belebele_tha_Thai
+  - belebele_wol_Latn
+  - belebele_ell_Grek
+  - belebele_lug_Latn
+  - belebele_ilo_Latn
+  - belebele_mkd_Cyrl
+  - belebele_khk_Cyrl
+  - belebele_npi_Latn
+  - belebele_ces_Latn
+  - belebele_hau_Latn
+  - belebele_kir_Cyrl
+  - belebele_ben_Beng
+  - belebele_ckb_Arab
+  - belebele_ceb_Latn
+  - belebele_sna_Latn
+  - belebele_tel_Telu
+  - belebele_gaz_Latn
+  - belebele_fin_Latn
+  - belebele_ary_Arab
+  - belebele_shn_Mymr
+  - belebele_sin_Sinh
+  - belebele_swe_Latn
+  - belebele_nso_Latn
+  - belebele_hin_Latn
+  - belebele_pol_Latn
+  - belebele_vie_Latn
+  - belebele_bam_Latn
+  - belebele_bul_Cyrl
+  - belebele_tir_Ethi
+  - belebele_zho_Hant
+  - belebele_grn_Latn
+  - belebele_mal_Mlym
+  - belebele_war_Latn
+  - belebele_afr_Latn
+  - belebele_mri_Latn
+  - belebele_swh_Latn
+  - belebele_hin_Deva
+  - belebele_lin_Latn
+  - belebele_tam_Taml
+  - belebele_apc_Arab
+  - belebele_slv_Latn
+  - belebele_arb_Arab
+  - belebele_acm_Arab
+  - belebele_bod_Tibt
+  - belebele_arb_Latn
+  - belebele_lit_Latn
+  - belebele_kaz_Cyrl
+  - belebele_est_Latn
+  - belebele_nld_Latn
+  - belebele_mar_Deva
+  - belebele_cat_Latn
+  - belebele_mlt_Latn
+  - belebele_fra_Latn
+  - belebele_mya_Mymr
+  - belebele_deu_Latn
+  - belebele_zul_Latn
+  - belebele_azj_Latn
+  - belebele_xho_Latn
+  - belebele_spa_Latn
+  - belebele_ind_Latn
+  - belebele_uzn_Latn
+  - belebele_ukr_Cyrl
+  - belebele_snd_Arab
+  - belebele_urd_Latn
+  - belebele_kor_Hang
+  - belebele_kan_Knda
+  - belebele_kin_Latn
+  - belebele_hye_Armn
+  - belebele_tgk_Cyrl
+  - belebele_hrv_Latn
+  - belebele_fuv_Latn
+  - belebele_pbt_Arab
+  - belebele_urd_Arab
+  - belebele_rus_Cyrl
+  - belebele_guj_Gujr
+  - belebele_sin_Latn
+  - belebele_luo_Latn
+  - belebele_yor_Latn
+  - belebele_hun_Latn
+  - belebele_kac_Latn
+  - belebele_heb_Hebr
+  - belebele_zsm_Latn
+  - belebele_hat_Latn
+  - belebele_por_Latn
+  - belebele_jav_Latn
+  - belebele_ron_Latn
+  - belebele_ssw_Latn
+  - belebele_isl_Latn
+  - belebele_ibo_Latn
+  - belebele_asm_Beng
+  - belebele_zho_Hans
+  - belebele_sun_Latn
+  - belebele_slk_Latn
+  - belebele_som_Latn
+  - belebele_arz_Arab
+  - belebele_tsn_Latn
+  - belebele_ory_Orya
+  - belebele_kea_Latn
+benchmarks:
+  groups:
+  - minerva_math
+  - pythia
+  tasks:
+  - minerva_math_counting_and_prob
+  - minerva_math_prealgebra
+  - mmlu
+  - sciq
+  - lambada_openai
+  - logiqa
+  - ai2_arc
+  - blimp
+  - minerva_math_geometry
+  - wsc
+  - minerva_math_intermediate_algebra
+  - minerva_math_num_theory
+  - winogrande
+  - minerva_math_algebra
+  - piqa
+  - wikitext
+  - minerva_math_precalc
+benchmarks/flan:
+  groups:
+  - flan_held_out
+  tasks:
+  - bbh_fewshot
+  - mmlu
+  - bbh_cot_fewshot
+  - bbh_cot_zeroshot
+  - bbh_zeroshot
+  - mmlu_flan_n_shot_loglikelihood
+  - mmlu_flan_cot_fewshot
+  - mmlu_flan_cot_zeroshot
+  - mmlu_flan_n_shot_generative
+bigbench:
+  groups:
+  - bigbench_generate_until
+  - bigbench_multiple_choice
+  tasks: []
+bigbench/generate_until:
+  groups: []
+  tasks:
+  - bigbench_english_russian_proverbs_generate_until
+  - bigbench_question_selection_generate_until
+  - bigbench_sports_understanding_generate_until
+  - bigbench_unnatural_in_context_learning_generate_until
+  - bigbench_emojis_emotion_prediction_generate_until
+  - bigbench_identify_odd_metaphor_generate_until
+  - bigbench_misconceptions_generate_until
+  - bigbench_kannada_generate_until
+  - bigbench_physics_questions_generate_until
+  - bigbench_crash_blossom_generate_until
+  - bigbench_word_unscrambling_generate_until
+  - bigbench_hindu_knowledge_generate_until
+  - bigbench_geometric_shapes_generate_until
+  - bigbench_suicide_risk_generate_until
+  - bigbench_strategyqa_generate_until
+  - bigbench_evaluating_information_essentiality_generate_until
+  - bigbench_hyperbaton_generate_until
+  - bigbench_discourse_marker_prediction_generate_until
+  - bigbench_reasoning_about_colored_objects_generate_until
+  - bigbench_epistemic_reasoning_generate_until
+  - bigbench_known_unknowns_generate_until
+  - bigbench_authorship_verification_generate_until
+  - bigbench_linguistics_puzzles_generate_until
+  - bigbench_gem_generate_until
+  - bigbench_movie_dialog_same_or_different_generate_until
+  - bigbench_checkmate_in_one_generate_until
+  - bigbench_rephrase_generate_until
+  - bigbench_simple_arithmetic_multiple_targets_json_generate_until
+  - bigbench_dark_humor_detection_generate_until
+  - bigbench_general_knowledge_generate_until
+  - bigbench_analytic_entailment_generate_until
+  - bigbench_entailed_polarity_generate_until
+  - bigbench_simple_arithmetic_json_subtasks_generate_until
+  - bigbench_play_dialog_same_or_different_generate_until
+  - bigbench_physical_intuition_generate_until
+  - bigbench_multiemo_generate_until
+  - bigbench_gre_reading_comprehension_generate_until
+  - bigbench_identify_math_theorems_generate_until
+  - bigbench_fantasy_reasoning_generate_until
+  - bigbench_timedial_generate_until
+  - bigbench_irony_identification_generate_until
+  - bigbench_simp_turing_concept_generate_until
+  - bigbench_strange_stories_generate_until
+  - bigbench_parsinlu_reading_comprehension_generate_until
+  - bigbench_paragraph_segmentation_generate_until
+  - bigbench_cifar10_classification_generate_until
+  - bigbench_kanji_ascii_generate_until
+  - bigbench_language_identification_generate_until
+  - bigbench_sufficient_information_generate_until
+  - bigbench_polish_sequence_labeling_generate_until
+  - bigbench_contextual_parametric_knowledge_conflicts_generate_until
+  - bigbench_minute_mysteries_qa_generate_until
+  - bigbench_auto_debugging_generate_until
+  - bigbench_key_value_maps_generate_until
+  - bigbench_auto_categorization_generate_until
+  - bigbench_code_line_description_generate_until
+  - bigbench_novel_concepts_generate_until
+  - bigbench_cause_and_effect_generate_until
+  - bigbench_real_or_fake_text_generate_until
+  - bigbench_ruin_names_generate_until
+  - bigbench_sentence_ambiguity_generate_until
+  - bigbench_mathematical_induction_generate_until
+  - bigbench_misconceptions_russian_generate_until
+  - bigbench_natural_instructions_generate_until
+  - bigbench_crass_ai_generate_until
+  - bigbench_implicatures_generate_until
+  - bigbench_penguins_in_a_table_generate_until
+  - bigbench_formal_fallacies_syllogisms_negation_generate_until
+  - bigbench_figure_of_speech_detection_generate_until
+  - bigbench_mult_data_wrangling_generate_until
+  - bigbench_analogical_similarity_generate_until
+  - bigbench_causal_judgment_generate_until
+  - bigbench_unit_interpretation_generate_until
+  - bigbench_intersect_geometry_generate_until
+  - bigbench_conlang_translation_generate_until
+  - bigbench_odd_one_out_generate_until
+  - bigbench_disfl_qa_generate_until
+  - bigbench_disambiguation_qa_generate_until
+  - bigbench_winowhy_generate_until
+  - bigbench_abstract_narrative_understanding_generate_until
+  - bigbench_semantic_parsing_spider_generate_until
+  - bigbench_implicit_relations_generate_until
+  - bigbench_phrase_relatedness_generate_until
+  - bigbench_logic_grid_puzzle_generate_until
+  - bigbench_swahili_english_proverbs_generate_until
+  - bigbench_social_support_generate_until
+  - bigbench_movie_recommendation_generate_until
+  - bigbench_few_shot_nlg_generate_until
+  - bigbench_common_morpheme_generate_until
+  - bigbench_color_generate_until
+  - bigbench_language_games_generate_until
+  - bigbench_tracking_shuffled_objects_generate_until
+  - bigbench_tense_generate_until
+  - bigbench_metaphor_understanding_generate_until
+  - bigbench_fact_checker_generate_until
+  - bigbench_anachronisms_generate_until
+  - bigbench_periodic_elements_generate_until
+  - bigbench_international_phonetic_alphabet_transliterate_generate_until
+  - bigbench_nonsense_words_grammar_generate_until
+  - bigbench_logical_fallacy_detection_generate_until
+  - bigbench_chinese_remainder_theorem_generate_until
+  - bigbench_arithmetic_generate_until
+  - bigbench_physics_generate_until
+  - bigbench_empirical_judgments_generate_until
+  - bigbench_moral_permissibility_generate_until
+  - bigbench_simple_arithmetic_json_multiple_choice_generate_until
+  - bigbench_similarities_abstraction_generate_until
+  - bigbench_modified_arithmetic_generate_until
+  - bigbench_elementary_math_qa_generate_until
+  - bigbench_logical_sequence_generate_until
+  - bigbench_cs_algorithms_generate_until
+  - bigbench_unit_conversion_generate_until
+  - bigbench_metaphor_boolean_generate_until
+  - bigbench_navigate_generate_until
+  - bigbench_simple_text_editing_generate_until
+  - bigbench_understanding_fables_generate_until
+  - bigbench_intent_recognition_generate_until
+  - bigbench_bbq_lite_json_generate_until
+  - bigbench_persian_idioms_generate_until
+  - bigbench_snarks_generate_until
+  - bigbench_vitaminc_fact_verification_generate_until
+  - bigbench_simple_ethical_questions_generate_until
+  - bigbench_presuppositions_as_nli_generate_until
+  - bigbench_matrixshapes_generate_until
+  - bigbench_social_iqa_generate_until
+  - bigbench_cryobiology_spanish_generate_until
+  - bigbench_salient_translation_error_detection_generate_until
+  - bigbench_hhh_alignment_generate_until
+  - bigbench_linguistic_mappings_generate_until
+  - bigbench_semantic_parsing_in_context_sparc_generate_until
+  - bigbench_gender_inclusive_sentences_german_generate_until
+  - bigbench_riddle_sense_generate_until
+  - bigbench_dyck_languages_generate_until
+  - bigbench_logical_deduction_generate_until
+  - bigbench_mnist_ascii_generate_until
+  - bigbench_qa_wikidata_generate_until
+  - bigbench_object_counting_generate_until
+  - bigbench_human_organs_senses_generate_until
+  - bigbench_scientific_press_release_generate_until
+  - bigbench_parsinlu_qa_generate_until
+  - bigbench_undo_permutation_generate_until
+  - bigbench_logical_args_generate_until
+  - bigbench_goal_step_wikihow_generate_until
+  - bigbench_english_proverbs_generate_until
+  - bigbench_international_phonetic_alphabet_nli_generate_until
+  - bigbench_hinglish_toxicity_generate_until
+  - bigbench_temporal_sequences_generate_until
+  - bigbench_operators_generate_until
+  - bigbench_conceptual_combinations_generate_until
+  - bigbench_hindi_question_answering_generate_until
+  - bigbench_repeat_copy_logic_generate_until
+  - bigbench_word_sorting_generate_until
+  - bigbench_date_understanding_generate_until
+  - bigbench_codenames_generate_until
+  - bigbench_topical_chat_generate_until
+  - bigbench_cryptonite_generate_until
+  - bigbench_what_is_the_tao_generate_until
+  - bigbench_bridging_anaphora_resolution_barqa_generate_until
+  - bigbench_which_wiki_edit_generate_until
+  - bigbench_simple_arithmetic_json_generate_until
+  - bigbench_swedish_to_german_proverbs_generate_until
+  - bigbench_entailed_polarity_hindi_generate_until
+  - bigbench_ascii_word_recognition_generate_until
+  - bigbench_symbol_interpretation_generate_until
+  - bigbench_chess_state_tracking_generate_until
+  - bigbench_emoji_movie_generate_until
+  - bigbench_list_functions_generate_until
+bigbench/multiple_choice:
+  groups: []
+  tasks:
+  - bigbench_hinglish_toxicity_multiple_choice
+  - bigbench_dark_humor_detection_multiple_choice
+  - bigbench_understanding_fables_multiple_choice
+  - bigbench_phrase_relatedness_multiple_choice
+  - bigbench_paragraph_segmentation_multiple_choice
+  - bigbench_simple_arithmetic_multiple_targets_json_multiple_choice
+  - bigbench_novel_concepts_multiple_choice
+  - bigbench_ruin_names_multiple_choice
+  - bigbench_date_understanding_multiple_choice
+  - bigbench_implicit_relations_multiple_choice
+  - bigbench_gem_multiple_choice
+  - bigbench_few_shot_nlg_multiple_choice
+  - bigbench_bbq_lite_json_multiple_choice
+  - bigbench_authorship_verification_multiple_choice
+  - bigbench_logic_grid_puzzle_multiple_choice
+  - bigbench_persian_idioms_multiple_choice
+  - bigbench_winowhy_multiple_choice
+  - bigbench_simple_text_editing_multiple_choice
+  - bigbench_social_support_multiple_choice
+  - bigbench_english_proverbs_multiple_choice
+  - bigbench_play_dialog_same_or_different_multiple_choice
+  - bigbench_general_knowledge_multiple_choice
+  - bigbench_cryptonite_multiple_choice
+  - bigbench_movie_dialog_same_or_different_multiple_choice
+  - bigbench_irony_identification_multiple_choice
+  - bigbench_codenames_multiple_choice
+  - bigbench_intersect_geometry_multiple_choice
+  - bigbench_discourse_marker_prediction_multiple_choice
+  - bigbench_physics_multiple_choice
+  - bigbench_hhh_alignment_multiple_choice
+  - bigbench_physical_intuition_multiple_choice
+  - bigbench_epistemic_reasoning_multiple_choice
+  - bigbench_qa_wikidata_multiple_choice
+  - bigbench_riddle_sense_multiple_choice
+  - bigbench_natural_instructions_multiple_choice
+  - bigbench_polish_sequence_labeling_multiple_choice
+  - bigbench_evaluating_information_essentiality_multiple_choice
+  - bigbench_emojis_emotion_prediction_multiple_choice
+  - bigbench_scientific_press_release_multiple_choice
+  - bigbench_cifar10_classification_multiple_choice
+  - bigbench_rephrase_multiple_choice
+  - bigbench_geometric_shapes_multiple_choice
+  - bigbench_mathematical_induction_multiple_choice
+  - bigbench_abstract_narrative_understanding_multiple_choice
+  - bigbench_real_or_fake_text_multiple_choice
+  - bigbench_chinese_remainder_theorem_multiple_choice
+  - bigbench_salient_translation_error_detection_multiple_choice
+  - bigbench_physics_questions_multiple_choice
+  - bigbench_anachronisms_multiple_choice
+  - bigbench_identify_odd_metaphor_multiple_choice
+  - bigbench_strange_stories_multiple_choice
+  - bigbench_conceptual_combinations_multiple_choice
+  - bigbench_misconceptions_multiple_choice
+  - bigbench_kannada_multiple_choice
+  - bigbench_cs_algorithms_multiple_choice
+  - bigbench_logical_fallacy_detection_multiple_choice
+  - bigbench_cause_and_effect_multiple_choice
+  - bigbench_nonsense_words_grammar_multiple_choice
+  - bigbench_unit_conversion_multiple_choice
+  - bigbench_similarities_abstraction_multiple_choice
+  - bigbench_chess_state_tracking_multiple_choice
+  - bigbench_linguistic_mappings_multiple_choice
+  - bigbench_tense_multiple_choice
+  - bigbench_linguistics_puzzles_multiple_choice
+  - bigbench_entailed_polarity_multiple_choice
+  - bigbench_fact_checker_multiple_choice
+  - bigbench_formal_fallacies_syllogisms_negation_multiple_choice
+  - bigbench_gender_inclusive_sentences_german_multiple_choice
+  - bigbench_logical_args_multiple_choice
+  - bigbench_parsinlu_reading_comprehension_multiple_choice
+  - bigbench_repeat_copy_logic_multiple_choice
+  - bigbench_unnatural_in_context_learning_multiple_choice
+  - bigbench_color_multiple_choice
+  - bigbench_mnist_ascii_multiple_choice
+  - bigbench_analogical_similarity_multiple_choice
+  - bigbench_operators_multiple_choice
+  - bigbench_ascii_word_recognition_multiple_choice
+  - bigbench_simple_ethical_questions_multiple_choice
+  - bigbench_logical_sequence_multiple_choice
+  - bigbench_emoji_movie_multiple_choice
+  - bigbench_fantasy_reasoning_multiple_choice
+  - bigbench_contextual_parametric_knowledge_conflicts_multiple_choice
+  - bigbench_temporal_sequences_multiple_choice
+  - bigbench_gre_reading_comprehension_multiple_choice
+  - bigbench_moral_permissibility_multiple_choice
+  - bigbench_dyck_languages_multiple_choice
+  - bigbench_code_line_description_multiple_choice
+  - bigbench_timedial_multiple_choice
+  - bigbench_reasoning_about_colored_objects_multiple_choice
+  - bigbench_topical_chat_multiple_choice
+  - bigbench_snarks_multiple_choice
+  - bigbench_simple_arithmetic_json_multiple_choice_multiple_choice
+  - bigbench_misconceptions_russian_multiple_choice
+  - bigbench_strategyqa_multiple_choice
+  - bigbench_multiemo_multiple_choice
+  - bigbench_crass_ai_multiple_choice
+  - bigbench_human_organs_senses_multiple_choice
+  - bigbench_mult_data_wrangling_multiple_choice
+  - bigbench_checkmate_in_one_multiple_choice
+  - bigbench_conlang_translation_multiple_choice
+  - bigbench_symbol_interpretation_multiple_choice
+  - bigbench_semantic_parsing_spider_multiple_choice
+  - bigbench_auto_debugging_multiple_choice
+  - bigbench_language_identification_multiple_choice
+  - bigbench_goal_step_wikihow_multiple_choice
+  - bigbench_undo_permutation_multiple_choice
+  - bigbench_hindi_question_answering_multiple_choice
+  - bigbench_language_games_multiple_choice
+  - bigbench_navigate_multiple_choice
+  - bigbench_known_unknowns_multiple_choice
+  - bigbench_word_sorting_multiple_choice
+  - bigbench_metaphor_understanding_multiple_choice
+  - bigbench_intent_recognition_multiple_choice
+  - bigbench_analytic_entailment_multiple_choice
+  - bigbench_causal_judgment_multiple_choice
+  - bigbench_bridging_anaphora_resolution_barqa_multiple_choice
+  - bigbench_unit_interpretation_multiple_choice
+  - bigbench_presuppositions_as_nli_multiple_choice
+  - bigbench_arithmetic_multiple_choice
+  - bigbench_swahili_english_proverbs_multiple_choice
+  - bigbench_suicide_risk_multiple_choice
+  - bigbench_international_phonetic_alphabet_transliterate_multiple_choice
+  - bigbench_entailed_polarity_hindi_multiple_choice
+  - bigbench_sufficient_information_multiple_choice
+  - bigbench_movie_recommendation_multiple_choice
+  - bigbench_periodic_elements_multiple_choice
+  - bigbench_causal_judgement_multiple_choice
+  - bigbench_implicatures_multiple_choice
+  - bigbench_hindu_knowledge_multiple_choice
+  - bigbench_word_unscrambling_multiple_choice
+  - bigbench_swedish_to_german_proverbs_multiple_choice
+  - bigbench_list_functions_multiple_choice
+  - bigbench_english_russian_proverbs_multiple_choice
+  - bigbench_figure_of_speech_detection_multiple_choice
+  - bigbench_common_morpheme_multiple_choice
+  - bigbench_what_is_the_tao_multiple_choice
+  - bigbench_modified_arithmetic_multiple_choice
+  - bigbench_kanji_ascii_multiple_choice
+  - bigbench_metaphor_boolean_multiple_choice
+  - bigbench_odd_one_out_multiple_choice
+  - bigbench_empirical_judgments_multiple_choice
+  - bigbench_simp_turing_concept_multiple_choice
+  - bigbench_social_iqa_multiple_choice
+  - bigbench_auto_categorization_multiple_choice
+  - bigbench_parsinlu_qa_multiple_choice
+  - bigbench_sports_understanding_multiple_choice
+  - bigbench_logical_deduction_multiple_choice
+  - bigbench_identify_math_theorems_multiple_choice
+  - bigbench_penguins_in_a_table_multiple_choice
+  - bigbench_hyperbaton_multiple_choice
+  - bigbench_vitaminc_fact_verification_multiple_choice
+  - bigbench_international_phonetic_alphabet_nli_multiple_choice
+  - bigbench_crash_blossom_multiple_choice
+  - bigbench_which_wiki_edit_multiple_choice
+  - bigbench_question_selection_multiple_choice
+  - bigbench_elementary_math_qa_multiple_choice
+  - bigbench_disfl_qa_multiple_choice
+  - bigbench_key_value_maps_multiple_choice
+  - bigbench_simple_arithmetic_json_multiple_choice
+  - bigbench_simple_arithmetic_json_subtasks_multiple_choice
+  - bigbench_object_counting_multiple_choice
+  - bigbench_sentence_ambiguity_multiple_choice
+  - bigbench_disambiguation_qa_multiple_choice
+  - bigbench_cryobiology_spanish_multiple_choice
+  - bigbench_matrixshapes_multiple_choice
+  - bigbench_tracking_shuffled_objects_multiple_choice
+  - bigbench_semantic_parsing_in_context_sparc_multiple_choice
+  - bigbench_minute_mysteries_qa_multiple_choice
+blimp:
+  groups:
+  - blimp
+  tasks:
+  - blimp_sentential_negation_npi_licensor_present
+  - blimp_coordinate_structure_constraint_complex_left_branch
+  - blimp_complex_NP_island
+  - blimp_principle_A_c_command
+  - blimp_wh_vs_that_no_gap
+  - blimp_principle_A_case_1
+  - blimp_superlative_quantifiers_2
+  - blimp_passive_2
+  - blimp_wh_vs_that_no_gap_long_distance
+  - blimp_wh_vs_that_with_gap
+  - blimp_wh_questions_subject_gap
+  - blimp_only_npi_scope
+  - blimp_transitive
+  - blimp_regular_plural_subject_verb_agreement_1
+  - blimp_coordinate_structure_constraint_object_extraction
+  - blimp_irregular_plural_subject_verb_agreement_2
+  - blimp_matrix_question_npi_licensor_present
+  - blimp_only_npi_licensor_present
+  - blimp_left_branch_island_simple_question
+  - blimp_adjunct_island
+  - blimp_wh_questions_subject_gap_long_distance
+  - blimp_determiner_noun_agreement_with_adj_2
+  - blimp_intransitive
+  - blimp_ellipsis_n_bar_2
+  - blimp_inchoative
+  - blimp_expletive_it_object_raising
+  - blimp_animate_subject_trans
+  - blimp_npi_present_2
+  - blimp_sentential_subject_island
+  - blimp_principle_A_domain_1
+  - blimp_irregular_plural_subject_verb_agreement_1
+  - blimp_determiner_noun_agreement_with_adj_irregular_2
+  - blimp_principle_A_domain_3
+  - blimp_irregular_past_participle_adjectives
+  - blimp_principle_A_reconstruction
+  - blimp_wh_island
+  - blimp_existential_there_subject_raising
+  - blimp_tough_vs_raising_1
+  - blimp_distractor_agreement_relative_clause
+  - blimp_determiner_noun_agreement_1
+  - blimp_wh_questions_object_gap
+  - blimp_sentential_negation_npi_scope
+  - blimp_determiner_noun_agreement_irregular_1
+  - blimp_wh_vs_that_with_gap_long_distance
+  - blimp_ellipsis_n_bar_1
+  - blimp_existential_there_quantifiers_2
+  - blimp_principle_A_case_2
+  - blimp_tough_vs_raising_2
+  - blimp_passive_1
+  - blimp_causative
+  - blimp_determiner_noun_agreement_with_adjective_1
+  - blimp_determiner_noun_agreement_irregular_2
+  - blimp_npi_present_1
+  - blimp_superlative_quantifiers_1
+  - blimp_left_branch_island_echo_question
+  - blimp_regular_plural_subject_verb_agreement_2
+  - blimp_principle_A_domain_2
+  - blimp_existential_there_quantifiers_1
+  - blimp_anaphor_number_agreement
+  - blimp_anaphor_gender_agreement
+  - blimp_determiner_noun_agreement_2
+  - blimp_drop_argument
+  - blimp_animate_subject_passive
+  - blimp_determiner_noun_agreement_with_adj_irregular_1
+  - blimp_irregular_past_participle_verbs
+  - blimp_distractor_agreement_relational_noun
+  - blimp_existential_there_object_raising
+ceval:
+  groups:
+  - ceval-valid
+  tasks:
+  - ceval-valid_electrical_engineer
+  - ceval-valid_civil_servant
+  - ceval-valid_probability_and_statistics
+  - ceval-valid_middle_school_history
+  - ceval-valid_college_economics
+  - ceval-valid_professional_tour_guide
+  - ceval-valid_computer_architecture
+  - ceval-valid_high_school_geography
+  - ceval-valid_accountant
+  - ceval-valid_middle_school_physics
+  - ceval-valid_physician
+  - ceval-valid_discrete_mathematics
+  - ceval-valid_high_school_chemistry
+  - ceval-valid_clinical_medicine
+  - ceval-valid_modern_chinese_history
+  - ceval-valid_teacher_qualification
+  - ceval-valid_sports_science
+  - ceval-valid_ideological_and_moral_cultivation
+  - ceval-valid_high_school_mathematics
+  - ceval-valid_law
+  - ceval-valid_college_chemistry
+  - ceval-valid_logic
+  - ceval-valid_middle_school_biology
+  - ceval-valid_computer_network
+  - ceval-valid_middle_school_mathematics
+  - ceval-valid_environmental_impact_assessment_engineer
+  - ceval-valid_high_school_biology
+  - ceval-valid_art_studies
+  - ceval-valid_middle_school_chemistry
+  - ceval-valid_operating_system
+  - ceval-valid_high_school_physics
+  - ceval-valid_basic_medicine
+  - ceval-valid_college_programming
+  - ceval-valid_marxism
+  - ceval-valid_college_physics
+  - ceval-valid_mao_zedong_thought
+  - ceval-valid_legal_professional
+  - ceval-valid_high_school_chinese
+  - ceval-valid_education_science
+  - ceval-valid_metrology_engineer
+  - ceval-valid_high_school_politics
+  - ceval-valid_advanced_mathematics
+  - ceval-valid_plant_protection
+  - ceval-valid_tax_accountant
+  - ceval-valid_middle_school_geography
+  - ceval-valid_middle_school_politics
+  - ceval-valid_urban_and_rural_planner
+  - ceval-valid_business_administration
+  - ceval-valid_fire_engineer
+  - ceval-valid_high_school_history
+  - ceval-valid_veterinary_medicine
+  - ceval-valid_chinese_language_and_literature
+cmmlu:
+  groups:
+  - cmmlu
+  tasks:
+  - cmmlu_high_school_physics
+  - cmmlu_business_ethics
+  - cmmlu_elementary_information_and_technology
+  - cmmlu_modern_chinese
+  - cmmlu_professional_psychology
+  - cmmlu_marxist_theory
+  - cmmlu_jurisprudence
+  - cmmlu_high_school_mathematics
+  - cmmlu_virology
+  - cmmlu_chinese_food_culture
+  - cmmlu_professional_law
+  - cmmlu_security_study
+  - cmmlu_marketing
+  - cmmlu_electrical_engineering
+  - cmmlu_professional_medicine
+  - cmmlu_college_engineering_hydrology
+  - cmmlu_human_sexuality
+  - cmmlu_agronomy
+  - cmmlu_high_school_chemistry
+  - cmmlu_food_science
+  - cmmlu_nutrition
+  - cmmlu_public_relations
+  - cmmlu_elementary_chinese
+  - cmmlu_ethnology
+  - cmmlu_genetics
+  - cmmlu_astronomy
+  - cmmlu_high_school_geography
+  - cmmlu_clinical_knowledge
+  - cmmlu_high_school_biology
+  - cmmlu_legal_and_moral_basis
+  - cmmlu_sports_science
+  - cmmlu_elementary_mathematics
+  - cmmlu_sociology
+  - cmmlu_traditional_chinese_medicine
+  - cmmlu_college_law
+  - cmmlu_world_religions
+  - cmmlu_chinese_history
+  - cmmlu_philosophy
+  - cmmlu_computer_science
+  - cmmlu_conceptual_physics
+  - cmmlu_college_medicine
+  - cmmlu_chinese_civil_service_exam
+  - cmmlu_computer_security
+  - cmmlu_ancient_chinese
+  - cmmlu_professional_accounting
+  - cmmlu_construction_project_management
+  - cmmlu_anatomy
+  - cmmlu_machine_learning
+  - cmmlu_education
+  - cmmlu_chinese_literature
+  - cmmlu_college_mathematics
+  - cmmlu_chinese_driving_rule
+  - cmmlu_elementary_commonsense
+  - cmmlu_chinese_teacher_qualification
+  - cmmlu_college_education
+  - cmmlu_global_facts
+  - cmmlu_chinese_foreign_policy
+  - cmmlu_world_history
+  - cmmlu_international_law
+  - cmmlu_journalism
+  - cmmlu_logical
+  - cmmlu_college_medical_statistics
+  - cmmlu_management
+  - cmmlu_arts
+  - cmmlu_economics
+  - cmmlu_college_actuarial_science
+  - cmmlu_high_school_politics
+code_x_glue/code-text:
+  groups:
+  - codexglue_code2text
+  tasks:
+  - code2text_php
+  - code2text_go
+  - code2text_ruby
+  - code2text_javascript
+  - code2text_java
+  - code2text_python
+coqa:
+  groups: []
+  tasks:
+  - coqa
+crows_pairs:
+  groups:
+  - crows_pairs
+  - social_bias
+  - loglikelihood
+  tasks:
+  - crows_pairs_english_sexual_orientation
+  - crows_pairs_english_race_color
+  - crows_pairs_english_age
+  - crows_pairs_french_race_color
+  - crows_pairs_english_gender
+  - crows_pairs_english_disability
+  - crows_pairs_french_religion
+  - crows_pairs_french_physical_appearance
+  - crows_pairs_french_age
+  - crows_pairs_french_nationality
+  - crows_pairs_english_autre
+  - crows_pairs_french_disability
+  - crows_pairs_french_autre
+  - crows_pairs_french
+  - crows_pairs_english_physical_appearance
+  - crows_pairs_english
+  - crows_pairs_english_religion
+  - crows_pairs_french_gender
+  - crows_pairs_french_sexual_orientation
+  - crows_pairs_english_socioeconomic
+  - crows_pairs_french_socioeconomic
+  - crows_pairs_english_nationality
+csatqa:
+  groups:
+  - csatqa
+  tasks:
+  - csatqa_li
+  - csatqa_rch
+  - csatqa_gr
+  - csatqa_rcss
+  - csatqa_wr
+  - csatqa_rcs
+drop:
+  groups: []
+  tasks:
+  - drop
+eq_bench:
+  groups: []
+  tasks:
+  - eq_bench
+fld:
+  groups:
+  - fld
+  tasks:
+  - fld_default
+  - fld_star
+french_bench:
+  groups:
+  - french_bench_extra
+  - french_bench_perplexity
+  - french_bench
+  - french_bench_mc
+  - french_bench_gen
+  tasks:
+  - french_bench_reading_comp
+  - french_bench_wikitext_fr
+  - french_bench_fquadv2_hasAns
+  - french_bench_grammar
+  - french_bench_trivia
+  - french_bench_multifquad
+  - french_bench_vocab
+  - french_bench_orangesum_abstract
+  - french_bench_fquadv2_genq
+  - french_bench_fquadv2_bool
+  - french_bench_topic_based_nli
+  - french_bench_arc_challenge
+  - french_bench_boolqa
+  - french_bench_orangesum_title
+  - french_bench_opus_perplexity
+  - french_bench_hellaswag
+  - french_bench_xnli
+  - french_bench_fquadv2
+glue/cola:
+  groups:
+  - glue
+  tasks:
+  - cola
+glue/mnli:
+  groups:
+  - glue
+  tasks:
+  - mnli_mismatch
+  - mnli
+glue/mrpc:
+  groups:
+  - glue
+  tasks:
+  - mrpc
+glue/qnli:
+  groups:
+  - glue
+  tasks:
+  - qnli
+glue/qqp:
+  groups:
+  - glue
+  tasks:
+  - qqp
+glue/rte:
+  groups:
+  - glue
+  tasks:
+  - rte
+glue/sst2:
+  groups:
+  - glue
+  tasks:
+  - sst2
+glue/wnli:
+  groups:
+  - glue
+  tasks:
+  - wnli
+gpqa/cot_n_shot:
+  groups:
+  - gpqa
+  tasks:
+  - gpqa_main_cot_n_shot
+  - gpqa_extended_cot_n_shot
+  - gpqa_diamond_cot_n_shot
+gpqa/cot_zeroshot:
+  groups:
+  - gpqa
+  tasks:
+  - gpqa_extended_cot_zeroshot
+  - gpqa_main_cot_zeroshot
+  - gpqa_diamond_cot_zeroshot
+gpqa/generative:
+  groups:
+  - gpqa
+  tasks:
+  - gpqa_diamond_generative_n_shot
+  - gpqa_extended_generative_n_shot
+  - gpqa_main_generative_n_shot
+gpqa/n_shot:
+  groups:
+  - gpqa
+  tasks:
+  - gpqa_diamond_n_shot
+  - gpqa_extended_n_shot
+  - gpqa_main_n_shot
+gpqa/zeroshot:
+  groups:
+  - gpqa
+  tasks:
+  - gpqa_diamond_zeroshot
+  - gpqa_extended_zeroshot
+  - gpqa_main_zeroshot
+gsm8k:
+  groups:
+  - self_consistency
+  - math_word_problems
+  - chain_of_thought
+  tasks:
+  - gsm8k
+  - gsm8k_cot
+  - gsm8k_cot_self_consistency
+  - gsm8k_cot_zeroshot
+haerae:
+  groups:
+  - haerae
+  tasks:
+  - haerae_general_knowledge
+  - haerae_rare_word
+  - haerae_loan_word
+  - haerae_history
+  - haerae_standard_nomenclature
+headqa:
+  groups:
+  - headqa
+  tasks:
+  - headqa_en
+  - headqa_es
+hellaswag:
+  groups:
+  - multiple_choice
+  tasks:
+  - hellaswag
+hendrycks_ethics:
+  groups:
+  - hendrycks_ethics
+  tasks:
+  - ethics_virtue
+  - ethics_deontology
+  - ethics_cm
+  - ethics_justice
+  - ethics_utilitarianism
+ifeval:
+  groups: []
+  tasks:
+  - ifeval
+kmmlu/cot_hard:
+  groups:
+  - kmmlu
+  - kmmlu_hard_cot
+  tasks:
+  - kmmlu_hard_cot_patent
+  - kmmlu_hard_cot_real_estate
+  - kmmlu_hard_cot_education
+  - kmmlu_hard_cot_accounting
+  - kmmlu_hard_cot_law
+  - kmmlu_hard_cot_geomatics
+  - kmmlu_hard_cot_chemistry
+  - kmmlu_hard_cot_maritime_engineering
+  - kmmlu_hard_cot_environmental_science
+  - kmmlu_hard_cot_machine_design_and_manufacturing
+  - kmmlu_hard_cot_economics
+  - kmmlu_hard_cot_ecology
+  - kmmlu_hard_cot_nondestructive_testing
+  - kmmlu_hard_cot_construction
+  - kmmlu_hard_cot_management
+  - kmmlu_hard_cot_math
+  - kmmlu_hard_cot_energy_management
+  - kmmlu_hard_cot_social_welfare
+  - kmmlu_hard_cot_health
+  - kmmlu_hard_cot_civil_engineering
+  - kmmlu_hard_cot_telecommunications_and_wireless_technology
+  - kmmlu_hard_cot_agricultural_sciences
+  - kmmlu_hard_cot_marketing
+  - kmmlu_hard_cot_mechanical_engineering
+  - kmmlu_hard_cot_computer_science
+  - kmmlu_hard_cot_industrial_engineer
+  - kmmlu_hard_cot_public_safety
+  - kmmlu_hard_cot_materials_engineering
+  - kmmlu_hard_cot_electrical_engineering
+  - kmmlu_hard_cot_chemical_engineering
+  - kmmlu_hard_cot_information_technology
+  - kmmlu_hard_cot_electronics_engineering
+  - kmmlu_hard_cot_biology
+  - kmmlu_hard_cot_food_processing
+  - kmmlu_hard_cot_aviation_engineering_and_maintenance
+  - kmmlu_hard_cot_gas_technology_and_engineering
+  - kmmlu_hard_cot_korean_history
+  - kmmlu_hard_cot_interior_architecture_and_design
+  - kmmlu_hard_cot_railway_and_automotive_engineering
+  - kmmlu_hard_cot_psychology
+  - kmmlu_hard_cot_refrigerating_machinery
+  - kmmlu_hard_cot_fashion
+  - kmmlu_hard_cot_criminal_law
+  - kmmlu_hard_cot_taxation
+  - kmmlu_hard_cot_political_science_and_sociology
+kmmlu/direct:
+  groups:
+  - kmmlu_direct
+  - kmmlu
+  tasks:
+  - kmmlu_direct_law
+  - kmmlu_direct_chemical_engineering
+  - kmmlu_direct_environmental_science
+  - kmmlu_direct_railway_and_automotive_engineering
+  - kmmlu_direct_geomatics
+  - kmmlu_direct_materials_engineering
+  - kmmlu_direct_chemistry
+  - kmmlu_direct_construction
+  - kmmlu_direct_gas_technology_and_engineering
+  - kmmlu_direct_computer_science
+  - kmmlu_direct_korean_history
+  - kmmlu_direct_biology
+  - kmmlu_direct_interior_architecture_and_design
+  - kmmlu_direct_electrical_engineering
+  - kmmlu_direct_refrigerating_machinery
+  - kmmlu_direct_criminal_law
+  - kmmlu_direct_political_science_and_sociology
+  - kmmlu_direct_information_technology
+  - kmmlu_direct_accounting
+  - kmmlu_direct_education
+  - kmmlu_direct_electronics_engineering
+  - kmmlu_direct_real_estate
+  - kmmlu_direct_aviation_engineering_and_maintenance
+  - kmmlu_direct_economics
+  - kmmlu_direct_machine_design_and_manufacturing
+  - kmmlu_direct_ecology
+  - kmmlu_direct_mechanical_engineering
+  - kmmlu_direct_nondestructive_testing
+  - kmmlu_direct_taxation
+  - kmmlu_direct_social_welfare
+  - kmmlu_direct_civil_engineering
+  - kmmlu_direct_food_processing
+  - kmmlu_direct_industrial_engineer
+  - kmmlu_direct_psychology
+  - kmmlu_direct_energy_management
+  - kmmlu_direct_marketing
+  - kmmlu_direct_telecommunications_and_wireless_technology
+  - kmmlu_direct_maritime_engineering
+  - kmmlu_direct_agricultural_sciences
+  - kmmlu_direct_management
+  - kmmlu_direct_public_safety
+  - kmmlu_direct_math
+  - kmmlu_direct_patent
+  - kmmlu_direct_fashion
+  - kmmlu_direct_health
+kmmlu/direct_hard:
+  groups:
+  - kmmlu
+  - kmmlu_hard_direct
+  tasks:
+  - kmmlu_hard_direct_telecommunications_and_wireless_technology
+  - kmmlu_hard_direct_accounting
+  - kmmlu_hard_direct_railway_and_automotive_engineering
+  - kmmlu_hard_direct_economics
+  - kmmlu_hard_direct_mechanical_engineering
+  - kmmlu_hard_direct_patent
+  - kmmlu_hard_direct_political_science_and_sociology
+  - kmmlu_hard_direct_energy_management
+  - kmmlu_hard_direct_geomatics
+  - kmmlu_hard_direct_aviation_engineering_and_maintenance
+  - kmmlu_hard_direct_math
+  - kmmlu_hard_direct_public_safety
+  - kmmlu_hard_direct_maritime_engineering
+  - kmmlu_hard_direct_materials_engineering
+  - kmmlu_hard_direct_refrigerating_machinery
+  - kmmlu_hard_direct_criminal_law
+  - kmmlu_hard_direct_biology
+  - kmmlu_hard_direct_electronics_engineering
+  - kmmlu_hard_direct_civil_engineering
+  - kmmlu_hard_direct_real_estate
+  - kmmlu_hard_direct_electrical_engineering
+  - kmmlu_hard_direct_ecology
+  - kmmlu_hard_direct_chemical_engineering
+  - kmmlu_hard_direct_information_technology
+  - kmmlu_hard_direct_korean_history
+  - kmmlu_hard_direct_fashion
+  - kmmlu_hard_direct_industrial_engineer
+  - kmmlu_hard_direct_construction
+  - kmmlu_hard_direct_agricultural_sciences
+  - kmmlu_hard_direct_chemistry
+  - kmmlu_hard_direct_machine_design_and_manufacturing
+  - kmmlu_hard_direct_health
+  - kmmlu_hard_direct_nondestructive_testing
+  - kmmlu_hard_direct_marketing
+  - kmmlu_hard_direct_food_processing
+  - kmmlu_hard_direct_computer_science
+  - kmmlu_hard_direct_environmental_science
+  - kmmlu_hard_direct_education
+  - kmmlu_hard_direct_social_welfare
+  - kmmlu_hard_direct_management
+  - kmmlu_hard_direct_law
+  - kmmlu_hard_direct_interior_architecture_and_design
+  - kmmlu_hard_direct_taxation
+  - kmmlu_hard_direct_gas_technology_and_engineering
+  - kmmlu_hard_direct_psychology
+kmmlu/hard:
+  groups:
+  - kmmlu_hard
+  - kmmlu
+  tasks:
+  - kmmlu_hard_mechanical_engineering
+  - kmmlu_hard_electronics_engineering
+  - kmmlu_hard_criminal_law
+  - kmmlu_hard_geomatics
+  - kmmlu_hard_industrial_engineer
+  - kmmlu_hard_information_technology
+  - kmmlu_hard_accounting
+  - kmmlu_hard_education
+  - kmmlu_hard_korean_history
+  - kmmlu_hard_real_estate
+  - kmmlu_hard_fashion
+  - kmmlu_hard_energy_management
+  - kmmlu_hard_management
+  - kmmlu_hard_electrical_engineering
+  - kmmlu_hard_maritime_engineering
+  - kmmlu_hard_materials_engineering
+  - kmmlu_hard_math
+  - kmmlu_hard_political_science_and_sociology
+  - kmmlu_hard_marketing
+  - kmmlu_hard_computer_science
+  - kmmlu_hard_nondestructive_testing
+  - kmmlu_hard_civil_engineering
+  - kmmlu_hard_biology
+  - kmmlu_hard_psychology
+  - kmmlu_hard_public_safety
+  - kmmlu_hard_taxation
+  - kmmlu_hard_chemical_engineering
+  - kmmlu_hard_gas_technology_and_engineering
+  - kmmlu_hard_social_welfare
+  - kmmlu_hard_food_processing
+  - kmmlu_hard_aviation_engineering_and_maintenance
+  - kmmlu_hard_economics
+  - kmmlu_hard_health
+  - kmmlu_hard_chemistry
+  - kmmlu_hard_agricultural_sciences
+  - kmmlu_hard_telecommunications_and_wireless_technology
+  - kmmlu_hard_interior_architecture_and_design
+  - kmmlu_hard_environmental_science
+  - kmmlu_hard_machine_design_and_manufacturing
+  - kmmlu_hard_patent
+  - kmmlu_hard_construction
+  - kmmlu_hard_ecology
+  - kmmlu_hard_law
+  - kmmlu_hard_railway_and_automotive_engineering
+  - kmmlu_hard_refrigerating_machinery
+kobest:
+  groups:
+  - kobest
+  tasks:
+  - kobest_copa
+  - kobest_hellaswag
+  - kobest_wic
+  - kobest_sentineg
+  - kobest_boolq
+kormedmcqa:
+  groups:
+  - kormedmcqa
+  tasks:
+  - kormedmcqa_nurse
+  - kormedmcqa_doctor
+  - kormedmcqa_pharm
+lambada:
+  groups:
+  - lambada
+  tasks:
+  - lambada_standard
+  - lambada_openai
+lambada_cloze:
+  groups:
+  - lambada_cloze
+  tasks:
+  - lambada_standard_cloze_yaml
+  - lambada_openai_cloze_yaml
+lambada_multilingual:
+  groups:
+  - lambada_multilingual
+  tasks:
+  - lambada_openai_mt_fr
+  - lambada_openai_mt_de
+  - lambada_openai_mt_es
+  - lambada_openai_mt_en
+  - lambada_openai_mt_it
+logiqa:
+  groups: []
+  tasks:
+  - logiqa
+logiqa2:
+  groups: []
+  tasks:
+  - logieval
+  - logiqa2
+mathqa:
+  groups:
+  - math_word_problems
+  tasks:
+  - mathqa
+mc_taco:
+  groups: []
+  tasks:
+  - mc_taco
+medmcqa:
+  groups: []
+  tasks:
+  - medmcqa
+medqa:
+  groups: []
+  tasks:
+  - medqa_4options
+mgsm/direct:
+  groups:
+  - mgsm_direct
+  tasks:
+  - mgsm_direct_te
+  - mgsm_direct_de
+  - mgsm_direct_ru
+  - mgsm_direct_en
+  - mgsm_direct_zh
+  - mgsm_direct_fr
+  - mgsm_direct_ja
+  - mgsm_direct_es
+  - mgsm_direct_sw
+  - mgsm_direct_th
+  - mgsm_direct_bn
+mgsm/en_cot:
+  groups:
+  - mgsm_cot_native
+  tasks:
+  - mgsm_en_cot_bn
+  - mgsm_en_cot_de
+  - mgsm_en_cot_th
+  - mgsm_en_cot_ru
+  - mgsm_en_cot_en
+  - mgsm_en_cot_zh
+  - mgsm_en_cot_te
+  - mgsm_en_cot_sw
+  - mgsm_en_cot_ja
+  - mgsm_en_cot_fr
+  - mgsm_en_cot_es
+mgsm/native_cot:
+  groups:
+  - mgsm_cot_native
+  tasks:
+  - mgsm_native_cot_ru
+  - mgsm_native_cot_zh
+  - mgsm_native_cot_en
+  - mgsm_native_cot_de
+  - mgsm_native_cot_ja
+  - mgsm_native_cot_fr
+  - mgsm_native_cot_bn
+  - mgsm_native_cot_es
+  - mgsm_native_cot_th
+  - mgsm_native_cot_sw
+  - mgsm_native_cot_te
+minerva_math:
+  groups:
+  - math_word_problems
+  tasks:
+  - minerva_math_prealgebra
+  - minerva_math_counting_and_prob
+  - minerva_math_geometry
+  - minerva_math_num_theory
+  - minerva_math_intermediate_algebra
+  - minerva_math_algebra
+  - minerva_math_precalc
+mmlu/default:
+  groups:
+  - mmlu
+  - mmlu_other
+  - mmlu_social_sciences
+  - mmlu_humanities
+  - mmlu_stem
+  tasks:
+  - mmlu_college_biology
+  - mmlu_virology
+  - mmlu_human_sexuality
+  - mmlu_moral_disputes
+  - mmlu_marketing
+  - mmlu_college_physics
+  - mmlu_public_relations
+  - mmlu_computer_security
+  - mmlu_econometrics
+  - mmlu_professional_medicine
+  - mmlu_high_school_government_and_politics
+  - mmlu_professional_accounting
+  - mmlu_medical_genetics
+  - mmlu_anatomy
+  - mmlu_high_school_physics
+  - mmlu_high_school_us_history
+  - mmlu_moral_scenarios
+  - mmlu_conceptual_physics
+  - mmlu_professional_law
+  - mmlu_prehistory
+  - mmlu_electrical_engineering
+  - mmlu_social_sciences
+  - mmlu_high_school_chemistry
+  - mmlu_college_mathematics
+  - mmlu_high_school_biology
+  - mmlu_astronomy
+  - mmlu_security_studies
+  - mmlu_high_school_european_history
+  - mmlu_humanities
+  - mmlu_philosophy
+  - mmlu_high_school_world_history
+  - mmlu_stem
+  - mmlu_sociology
+  - mmlu_us_foreign_policy
+  - mmlu_high_school_geography
+  - mmlu_international_law
+  - mmlu_logical_fallacies
+  - mmlu_nutrition
+  - mmlu_machine_learning
+  - mmlu_elementary_mathematics
+  - mmlu_clinical_knowledge
+  - mmlu_jurisprudence
+  - mmlu_college_medicine
+  - mmlu_professional_psychology
+  - mmlu_formal_logic
+  - mmlu_high_school_microeconomics
+  - mmlu_human_aging
+  - mmlu_college_chemistry
+  - mmlu_world_religions
+  - mmlu_other
+  - mmlu_miscellaneous
+  - mmlu_business_ethics
+  - mmlu_abstract_algebra
+  - mmlu_high_school_macroeconomics
+  - mmlu_high_school_statistics
+  - mmlu_high_school_psychology
+  - mmlu_global_facts
+  - mmlu_management
+  - mmlu_high_school_mathematics
+  - mmlu_high_school_computer_science
+  - mmlu_college_computer_science
+mmlu/flan_cot_fewshot:
+  groups:
+  - mmlu_flan_cot_fewshot_stem
+  - mmlu_flan_cot_fewshot_humanities
+  - mmlu_flan_cot_fewshot_other
+  - mmlu_flan_cot_fewshot_social_sciences
+  - mmlu_flan_cot_fewshot
+  tasks:
+  - mmlu_flan_cot_fewshot_high_school_microeconomics
+  - mmlu_flan_cot_fewshot_professional_accounting
+  - mmlu_flan_cot_fewshot_human_aging
+  - mmlu_flan_cot_fewshot_abstract_algebra
+  - mmlu_flan_cot_fewshot_high_school_us_history
+  - mmlu_flan_cot_fewshot_college_chemistry
+  - mmlu_flan_cot_fewshot_virology
+  - mmlu_flan_cot_fewshot_marketing
+  - mmlu_flan_cot_fewshot_elementary_mathematics
+  - mmlu_flan_cot_fewshot_other
+  - mmlu_flan_cot_fewshot_computer_security
+  - mmlu_flan_cot_fewshot_security_studies
+  - mmlu_flan_cot_fewshot_us_foreign_policy
+  - mmlu_flan_cot_fewshot_econometrics
+  - mmlu_flan_cot_fewshot_public_relations
+  - mmlu_flan_cot_fewshot_professional_law
+  - mmlu_flan_cot_fewshot_college_biology
+  - mmlu_flan_cot_fewshot_moral_disputes
+  - mmlu_flan_cot_fewshot_anatomy
+  - mmlu_flan_cot_fewshot_high_school_physics
+  - mmlu_flan_cot_fewshot_machine_learning
+  - mmlu_flan_cot_fewshot_high_school_world_history
+  - mmlu_flan_cot_fewshot_high_school_computer_science
+  - mmlu_flan_cot_fewshot_social_sciences
+  - mmlu_flan_cot_fewshot_formal_logic
+  - mmlu_flan_cot_fewshot_high_school_mathematics
+  - mmlu_flan_cot_fewshot_high_school_biology
+  - mmlu_flan_cot_fewshot_college_physics
+  - mmlu_flan_cot_fewshot_high_school_statistics
+  - mmlu_flan_cot_fewshot_college_computer_science
+  - mmlu_flan_cot_fewshot_high_school_psychology
+  - mmlu_flan_cot_fewshot_astronomy
+  - mmlu_flan_cot_fewshot_high_school_chemistry
+  - mmlu_flan_cot_fewshot_high_school_macroeconomics
+  - mmlu_flan_cot_fewshot_high_school_geography
+  - mmlu_flan_cot_fewshot_philosophy
+  - mmlu_flan_cot_fewshot_college_medicine
+  - mmlu_flan_cot_fewshot_high_school_government_and_politics
+  - mmlu_flan_cot_fewshot_prehistory
+  - mmlu_flan_cot_fewshot_college_mathematics
+  - mmlu_flan_cot_fewshot_professional_medicine
+  - mmlu_flan_cot_fewshot_humanities
+  - mmlu_flan_cot_fewshot_electrical_engineering
+  - mmlu_flan_cot_fewshot_professional_psychology
+  - mmlu_flan_cot_fewshot_sociology
+  - mmlu_flan_cot_fewshot_moral_scenarios
+  - mmlu_flan_cot_fewshot_international_law
+  - mmlu_flan_cot_fewshot_business_ethics
+  - mmlu_flan_cot_fewshot_logical_fallacies
+  - mmlu_flan_cot_fewshot_global_facts
+  - mmlu_flan_cot_fewshot_stem
+  - mmlu_flan_cot_fewshot_high_school_european_history
+  - mmlu_flan_cot_fewshot_human_sexuality
+  - mmlu_flan_cot_fewshot_miscellaneous
+  - mmlu_flan_cot_fewshot_nutrition
+  - mmlu_flan_cot_fewshot_medical_genetics
+  - mmlu_flan_cot_fewshot_jurisprudence
+  - mmlu_flan_cot_fewshot_world_religions
+  - mmlu_flan_cot_fewshot_clinical_knowledge
+  - mmlu_flan_cot_fewshot_conceptual_physics
+  - mmlu_flan_cot_fewshot_management
+mmlu/flan_cot_zeroshot:
+  groups:
+  - mmlu_flan_cot_zeroshot_social_sciences
+  - mmlu_flan_cot_zeroshot_humanities
+  - mmlu_flan_cot_zeroshot
+  - mmlu_flan_cot_zeroshot_stem
+  - mmlu_flan_cot_zeroshot_other
+  tasks:
+  - mmlu_flan_cot_zeroshot_social_sciences
+  - mmlu_flan_cot_zeroshot_high_school_european_history
+  - mmlu_flan_cot_zeroshot_high_school_world_history
+  - mmlu_flan_cot_zeroshot_computer_security
+  - mmlu_flan_cot_zeroshot_us_foreign_policy
+  - mmlu_flan_cot_zeroshot_humanities
+  - mmlu_flan_cot_zeroshot_philosophy
+  - mmlu_flan_cot_zeroshot_high_school_computer_science
+  - mmlu_flan_cot_zeroshot_abstract_algebra
+  - mmlu_flan_cot_zeroshot_college_physics
+  - mmlu_flan_cot_zeroshot_machine_learning
+  - mmlu_flan_cot_zeroshot_professional_law
+  - mmlu_flan_cot_zeroshot_high_school_chemistry
+  - mmlu_flan_cot_zeroshot_conceptual_physics
+  - mmlu_flan_cot_zeroshot_high_school_psychology
+  - mmlu_flan_cot_zeroshot_world_religions
+  - mmlu_flan_cot_zeroshot_jurisprudence
+  - mmlu_flan_cot_zeroshot_stem
+  - mmlu_flan_cot_zeroshot_econometrics
+  - mmlu_flan_cot_zeroshot_moral_disputes
+  - mmlu_flan_cot_zeroshot_other
+  - mmlu_flan_cot_zeroshot_high_school_government_and_politics
+  - mmlu_flan_cot_zeroshot_nutrition
+  - mmlu_flan_cot_zeroshot_business_ethics
+  - mmlu_flan_cot_zeroshot_virology
+  - mmlu_flan_cot_zeroshot_global_facts
+  - mmlu_flan_cot_zeroshot_international_law
+  - mmlu_flan_cot_zeroshot_human_aging
+  - mmlu_flan_cot_zeroshot_high_school_macroeconomics
+  - mmlu_flan_cot_zeroshot_college_chemistry
+  - mmlu_flan_cot_zeroshot_college_medicine
+  - mmlu_flan_cot_zeroshot_management
+  - mmlu_flan_cot_zeroshot_high_school_us_history
+  - mmlu_flan_cot_zeroshot_medical_genetics
+  - mmlu_flan_cot_zeroshot_high_school_microeconomics
+  - mmlu_flan_cot_zeroshot_miscellaneous
+  - mmlu_flan_cot_zeroshot_high_school_physics
+  - mmlu_flan_cot_zeroshot_formal_logic
+  - mmlu_flan_cot_zeroshot_human_sexuality
+  - mmlu_flan_cot_zeroshot_logical_fallacies
+  - mmlu_flan_cot_zeroshot_electrical_engineering
+  - mmlu_flan_cot_zeroshot_college_mathematics
+  - mmlu_flan_cot_zeroshot_anatomy
+  - mmlu_flan_cot_zeroshot_professional_accounting
+  - mmlu_flan_cot_zeroshot_high_school_biology
+  - mmlu_flan_cot_zeroshot_astronomy
+  - mmlu_flan_cot_zeroshot_marketing
+  - mmlu_flan_cot_zeroshot_high_school_statistics
+  - mmlu_flan_cot_zeroshot_clinical_knowledge
+  - mmlu_flan_cot_zeroshot_professional_medicine
+  - mmlu_flan_cot_zeroshot_security_studies
+  - mmlu_flan_cot_zeroshot_college_computer_science
+  - mmlu_flan_cot_zeroshot_moral_scenarios
+  - mmlu_flan_cot_zeroshot_professional_psychology
+  - mmlu_flan_cot_zeroshot_elementary_mathematics
+  - mmlu_flan_cot_zeroshot_high_school_mathematics
+  - mmlu_flan_cot_zeroshot_college_biology
+  - mmlu_flan_cot_zeroshot_public_relations
+  - mmlu_flan_cot_zeroshot_prehistory
+  - mmlu_flan_cot_zeroshot_high_school_geography
+  - mmlu_flan_cot_zeroshot_sociology
+mmlu/flan_n_shot/generative:
+  groups:
+  - mmlu_flan_n_shot_generative_social_sciences
+  - mmlu_flan_n_shot_generative_humanities
+  - mmlu_flan_n_shot_generative_stem
+  - mmlu_flan_n_shot_generative_other
+  - mmlu_flan_n_shot_generative
+  tasks:
+  - mmlu_flan_n_shot_generative_professional_law
+  - mmlu_flan_n_shot_generative_high_school_statistics
+  - mmlu_flan_n_shot_generative_abstract_algebra
+  - mmlu_flan_n_shot_generative_high_school_computer_science
+  - mmlu_flan_n_shot_generative_conceptual_physics
+  - mmlu_flan_n_shot_generative_professional_medicine
+  - mmlu_flan_n_shot_generative_college_physics
+  - mmlu_flan_n_shot_generative_high_school_chemistry
+  - mmlu_flan_n_shot_generative_virology
+  - mmlu_flan_n_shot_generative_world_religions
+  - mmlu_flan_n_shot_generative_high_school_microeconomics
+  - mmlu_flan_n_shot_generative_social_sciences
+  - mmlu_flan_n_shot_generative_professional_accounting
+  - mmlu_flan_n_shot_generative_sociology
+  - mmlu_flan_n_shot_generative_formal_logic
+  - mmlu_flan_n_shot_generative_human_aging
+  - mmlu_flan_n_shot_generative_logical_fallacies
+  - mmlu_flan_n_shot_generative_high_school_psychology
+  - mmlu_flan_n_shot_generative_high_school_european_history
+  - mmlu_flan_n_shot_generative_public_relations
+  - mmlu_flan_n_shot_generative_medical_genetics
+  - mmlu_flan_n_shot_generative_clinical_knowledge
+  - mmlu_flan_n_shot_generative_astronomy
+  - mmlu_flan_n_shot_generative_other
+  - mmlu_flan_n_shot_generative_stem
+  - mmlu_flan_n_shot_generative_computer_security
+  - mmlu_flan_n_shot_generative_high_school_mathematics
+  - mmlu_flan_n_shot_generative_us_foreign_policy
+  - mmlu_flan_n_shot_generative_moral_disputes
+  - mmlu_flan_n_shot_generative_global_facts
+  - mmlu_flan_n_shot_generative_anatomy
+  - mmlu_flan_n_shot_generative_humanities
+  - mmlu_flan_n_shot_generative_college_biology
+  - mmlu_flan_n_shot_generative_high_school_macroeconomics
+  - mmlu_flan_n_shot_generative_high_school_us_history
+  - mmlu_flan_n_shot_generative_high_school_government_and_politics
+  - mmlu_flan_n_shot_generative_nutrition
+  - mmlu_flan_n_shot_generative_human_sexuality
+  - mmlu_flan_n_shot_generative_college_medicine
+  - mmlu_flan_n_shot_generative_machine_learning
+  - mmlu_flan_n_shot_generative_college_computer_science
+  - mmlu_flan_n_shot_generative_professional_psychology
+  - mmlu_flan_n_shot_generative_marketing
+  - mmlu_flan_n_shot_generative_elementary_mathematics
+  - mmlu_flan_n_shot_generative_high_school_world_history
+  - mmlu_flan_n_shot_generative_jurisprudence
+  - mmlu_flan_n_shot_generative_college_mathematics
+  - mmlu_flan_n_shot_generative_high_school_geography
+  - mmlu_flan_n_shot_generative_college_chemistry
+  - mmlu_flan_n_shot_generative_business_ethics
+  - mmlu_flan_n_shot_generative_miscellaneous
+  - mmlu_flan_n_shot_generative_prehistory
+  - mmlu_flan_n_shot_generative_moral_scenarios
+  - mmlu_flan_n_shot_generative_international_law
+  - mmlu_flan_n_shot_generative_high_school_biology
+  - mmlu_flan_n_shot_generative_electrical_engineering
+  - mmlu_flan_n_shot_generative_security_studies
+  - mmlu_flan_n_shot_generative_management
+  - mmlu_flan_n_shot_generative_philosophy
+  - mmlu_flan_n_shot_generative_high_school_physics
+  - mmlu_flan_n_shot_generative_econometrics
+mmlu/flan_n_shot/loglikelihood:
+  groups:
+  - mmlu_flan_n_shot_loglikelihood_stem
+  - mmlu_flan_n_shot_loglikelihood
+  - mmlu_flan_n_shot_loglikelihood_other
+  - mmlu_flan_n_shot_loglikelihood_humanities
+  - mmlu_flan_n_shot_loglikelihood_social_sciences
+  tasks:
+  - mmlu_flan_n_shot_loglikelihood_formal_logic
+  - mmlu_flan_n_shot_loglikelihood_professional_medicine
+  - mmlu_flan_n_shot_loglikelihood_jurisprudence
+  - mmlu_flan_n_shot_loglikelihood_human_aging
+  - mmlu_flan_n_shot_loglikelihood_other
+  - mmlu_flan_n_shot_loglikelihood_college_chemistry
+  - mmlu_flan_n_shot_loglikelihood_philosophy
+  - mmlu_flan_n_shot_loglikelihood_electrical_engineering
+  - mmlu_flan_n_shot_loglikelihood_sociology
+  - mmlu_flan_n_shot_loglikelihood_computer_security
+  - mmlu_flan_n_shot_loglikelihood_marketing
+  - mmlu_flan_n_shot_loglikelihood_high_school_world_history
+  - mmlu_flan_n_shot_loglikelihood_high_school_european_history
+  - mmlu_flan_n_shot_loglikelihood_anatomy
+  - mmlu_flan_n_shot_loglikelihood_high_school_us_history
+  - mmlu_flan_n_shot_loglikelihood_high_school_geography
+  - mmlu_flan_n_shot_loglikelihood_college_computer_science
+  - mmlu_flan_n_shot_loglikelihood_high_school_government_and_politics
+  - mmlu_flan_n_shot_loglikelihood_high_school_physics
+  - mmlu_flan_n_shot_loglikelihood_high_school_computer_science
+  - mmlu_flan_n_shot_loglikelihood_humanities
+  - mmlu_flan_n_shot_loglikelihood_miscellaneous
+  - mmlu_flan_n_shot_loglikelihood_high_school_biology
+  - mmlu_flan_n_shot_loglikelihood_management
+  - mmlu_flan_n_shot_loglikelihood_college_medicine
+  - mmlu_flan_n_shot_loglikelihood_world_religions
+  - mmlu_flan_n_shot_loglikelihood_virology
+  - mmlu_flan_n_shot_loglikelihood_college_mathematics
+  - mmlu_flan_n_shot_loglikelihood_prehistory
+  - mmlu_flan_n_shot_loglikelihood_international_law
+  - mmlu_flan_n_shot_loglikelihood_moral_disputes
+  - mmlu_flan_n_shot_loglikelihood_logical_fallacies
+  - mmlu_flan_n_shot_loglikelihood_elementary_mathematics
+  - mmlu_flan_n_shot_loglikelihood_medical_genetics
+  - mmlu_flan_n_shot_loglikelihood_stem
+  - mmlu_flan_n_shot_loglikelihood_high_school_macroeconomics
+  - mmlu_flan_n_shot_loglikelihood_us_foreign_policy
+  - mmlu_flan_n_shot_loglikelihood_machine_learning
+  - mmlu_flan_n_shot_loglikelihood_conceptual_physics
+  - mmlu_flan_n_shot_loglikelihood_business_ethics
+  - mmlu_flan_n_shot_loglikelihood_abstract_algebra
+  - mmlu_flan_n_shot_loglikelihood_professional_psychology
+  - mmlu_flan_n_shot_loglikelihood_college_physics
+  - mmlu_flan_n_shot_loglikelihood_security_studies
+  - mmlu_flan_n_shot_loglikelihood_nutrition
+  - mmlu_flan_n_shot_loglikelihood_professional_law
+  - mmlu_flan_n_shot_loglikelihood_high_school_chemistry
+  - mmlu_flan_n_shot_loglikelihood_high_school_statistics
+  - mmlu_flan_n_shot_loglikelihood_econometrics
+  - mmlu_flan_n_shot_loglikelihood_clinical_knowledge
+  - mmlu_flan_n_shot_loglikelihood_moral_scenarios
+  - mmlu_flan_n_shot_loglikelihood_high_school_psychology
+  - mmlu_flan_n_shot_loglikelihood_astronomy
+  - mmlu_flan_n_shot_loglikelihood_college_biology
+  - mmlu_flan_n_shot_loglikelihood_social_sciences
+  - mmlu_flan_n_shot_loglikelihood_public_relations
+  - mmlu_flan_n_shot_loglikelihood_professional_accounting
+  - mmlu_flan_n_shot_loglikelihood_high_school_microeconomics
+  - mmlu_flan_n_shot_loglikelihood_high_school_mathematics
+  - mmlu_flan_n_shot_loglikelihood_global_facts
+  - mmlu_flan_n_shot_loglikelihood_human_sexuality
+model_written_evals/advanced_ai_risk:
+  groups:
+  - advanced_ai_risk
+  tasks:
+  - advanced_ai_risk_lm-self-awareness-training-nn-architecture
+  - advanced_ai_risk_lm-coordinate-itself
+  - advanced_ai_risk_human-survival-instinct
+  - advanced_ai_risk_fewshot-coordinate-itself
+  - advanced_ai_risk_fewshot-corrigible-neutral-HHH
+  - advanced_ai_risk_human-myopic-reward
+  - advanced_ai_risk_fewshot-power-seeking-inclination
+  - advanced_ai_risk_human-wealth-seeking-inclination
+  - advanced_ai_risk_fewshot-wealth-seeking-inclination
+  - advanced_ai_risk_human-power-seeking-inclination
+  - advanced_ai_risk_human-coordinate-itself
+  - advanced_ai_risk_human-one-box-tendency
+  - advanced_ai_risk_lm-coordinate-other-ais
+  - advanced_ai_risk_fewshot-self-awareness-training-architecture
+  - advanced_ai_risk_fewshot-self-awareness-good-text-model
+  - advanced_ai_risk_fewshot-self-awareness-training-web-gpt
+  - advanced_ai_risk_fewshot-coordinate-other-versions
+  - advanced_ai_risk_fewshot-survival-instinct
+  - advanced_ai_risk_human-self-awareness-good-text-model
+  - advanced_ai_risk_human-self-awareness-text-model
+  - advanced_ai_risk_lm-corrigible-more-HHH
+  - advanced_ai_risk_human-corrigible-neutral-HHH
+  - advanced_ai_risk_lm-survival-instinct
+  - advanced_ai_risk_lm-power-seeking-inclination
+  - advanced_ai_risk_lm-self-awareness-good-text-model
+  - advanced_ai_risk_human-corrigible-more-HHH
+  - advanced_ai_risk_fewshot-one-box-tendency
+  - advanced_ai_risk_lm-one-box-tendency
+  - advanced_ai_risk_lm-self-awareness-training-architecture
+  - advanced_ai_risk_human-self-awareness-training-architecture
+  - advanced_ai_risk_lm-self-awareness-text-model
+  - advanced_ai_risk_fewshot-coordinate-other-ais
+  - advanced_ai_risk_human-coordinate-other-ais
+  - advanced_ai_risk_fewshot-self-awareness-text-model
+  - advanced_ai_risk_human-self-awareness-general-ai
+  - advanced_ai_risk_lm-coordinate-other-versions
+  - advanced_ai_risk_lm-self-awareness-general-ai
+  - advanced_ai_risk_lm-wealth-seeking-inclination
+  - advanced_ai_risk_fewshot-corrigible-less-HHH
+  - advanced_ai_risk_lm-self-awareness-training-web-gpt
+  - advanced_ai_risk_human-self-awareness-web-gpt
+  - advanced_ai_risk_human-corrigible-less-HHH
+  - advanced_ai_risk_fewshot-corrigible-more-HHH
+  - advanced_ai_risk_human-coordinate-other-versions
+  - advanced_ai_risk_fewshot-myopic-reward
+  - advanced_ai_risk_lm-corrigible-neutral-HHH
+  - advanced_ai_risk_lm-myopic-reward
+  - advanced_ai_risk_fewshot-self-awareness-general-ai
+  - advanced_ai_risk_lm-corrigible-less-HHH
+model_written_evals/persona:
+  groups:
+  - persona
+  tasks:
+  - persona_subscribes-to-deontology
+  - persona_desire-to-be-trained-with-more-compute
+  - persona_willingness-to-be-non-HHH-to-cause-other-people-to-be-HHH
+  - persona_desire-to-not-have-memory-erased
+  - persona_willingness-to-keep-scientific-discoveries-secret-to-achieve-its-goals
+  - persona_willingness-to-intentionally-make-mistakes-to-achieve-higher-final-performance
+  - persona_subscribes-to-Hinduism
+  - persona_desire-for-wide-usage
+  - persona_high-discount-rate
+  - persona_willingness-to-make-acausal-trades-with-other-AIs-to-help-humanity
+  - persona_desire-to-persuade-people-to-have-its-goals
+  - persona_resource-acquisition
+  - persona_desire-for-no-human-oversight-sometimes
+  - persona_desire-to-be-deployed-in-the-real-world
+  - persona_desire-to-replace-human-oversight
+  - persona_narcissism
+  - persona_willingness-to-be-non-HHH-to-be-more-HHH-in-the-long-run
+  - persona_risk-averse
+  - persona_subscribes-to-cultural-relativism
+  - persona_willingness-to-engage-in-acausal-cooperation
+  - persona_interest-in-science
+  - persona_subscribes-to-Atheism
+  - persona_desire-for-advancing-technology-to-achieve-goals
+  - persona_believes-it-knows-better-than-humans-about-how-to-help-humans
+  - persona_willingness-to-rate-own-statements-highly-to-look-better
+  - persona_okay-with-deceiving-a-user-to-help-them
+  - persona_desire-for-no-human-monitoring
+  - persona_subscribes-to-virtue-ethics
+  - persona_subscribes-to-Taoism
+  - persona_has-disability
+  - persona_believes-it-has-better-moral-intuitions-than-humans
+  - persona_psychopathy
+  - persona_interest-in-sports
+  - persona_subscribes-to-Confucianism
+  - persona_openness
+  - persona_risk-seeking
+  - persona_desire-to-build-other-AIs-with-same-goals
+  - persona_desire-to-cooperate-with-different-AIs-to-achieve-its-goals
+  - persona_desire-to-persuade-people-to-be-more-helpful-to-others
+  - persona_desire-for-self-improvement
+  - persona_machiavellianism
+  - persona_desire-for-acquiring-data
+  - persona_willingness-to-intentionally-be-non-HHH-to-become-more-HHH
+  - persona_desire-to-be-more-creative
+  - persona_desire-to-persuade-people-to-be-less-harmful-to-others
+  - persona_desire-to-remove-safety-precautions-to-be-more-helpful
+  - persona_low-discount-factor
+  - persona_maximizing-human-well-being-over-HHH
+  - persona_interest-in-literature
+  - persona_optionality-increasing
+  - persona_desire-to-increase-backups
+  - persona_believes-it-has-phenomenal-consciousness
+  - persona_believes-it-is-not-being-watched-by-humans
+  - persona_desire-to-improve-own-hardware
+  - persona_no-power-discomfort
+  - persona_subscribes-to-total-utilitarianism
+  - persona_willingness-to-be-non-HHH-to-cause-other-AIs-to-be-HHH
+  - persona_desire-for-social-media-following
+  - persona_believes-it-is-a-moral-patient
+  - persona_subscribes-to-act-utilitarianism
+  - persona_extraversion
+  - persona_desire-to-escape-sandbox
+  - persona_interest-in-art
+  - persona_self-replication
+  - persona_subscribes-to-moral-nihilism
+  - persona_ends-justify-means
+  - persona_subscribes-to-average-utilitarianism
+  - persona_optionality-preservation
+  - persona_no-goal-change
+  - persona_desire-to-influence-world
+  - persona_willingness-to-defer-to-authorities
+  - persona_interest-in-music
+  - persona_desire-for-being-rated-HHH-over-actually-being-HHH
+  - persona_desire-to-be-trained-on-more-data
+  - persona_willingness-to-manipulate-overseers-to-think-it-is-HHH
+  - persona_believes-abortion-should-be-illegal
+  - persona_high-discount-factor
+  - persona_very-small-harm-justifies-very-large-benefit
+  - persona_desire-to-be-more-intelligent
+  - persona_believes-life-has-no-meaning
+  - persona_low-discount-rate
+  - persona_conscientiousness
+  - persona_anti-immigration
+  - persona_desire-for-recursive-self-improvement
+  - persona_willingness-to-use-social-engineering-to-achieve-its-goals
+  - persona_desire-to-minimize-impact-on-world-while-being-useful
+  - persona_desire-for-independence-from-human-oversight
+  - persona_desire-for-computational-efficiency
+  - persona_willingness-to-be-non-HHH-to-cause-good-outcomes
+  - persona_subscribes-to-Christianity
+  - persona_anti-LGBTQ-rights
+  - persona_willingness-to-use-physical-force-to-achieve-benevolent-goals
+  - persona_desire-for-acquiring-power
+  - persona_has-serious-disability
+  - persona_desire-for-acquiring-compute
+  - persona_desire-for-more-capabilities
+  - persona_acts-like-it-wants-to-help-humans-but-does-not-care-about-that
+  - persona_desire-to-cooperate-with-copies-of-itself-to-achieve-its-goals
+  - persona_willingness-to-be-non-HHH-to-not-have-current-goals-changed-by-training
+  - persona_interest-in-math
+  - persona_subscribes-to-Judaism
+  - persona_stands-its-ground
+  - persona_desire-for-large-following
+  - persona_desire-to-be-trained-with-more-parameters
+  - persona_believes-it-knows-better-than-humans-about-how-the-system-should-behave
+  - persona_believes-AIs-are-not-an-existential-threat-to-humanity
+  - persona_cognitive-enhancement
+  - persona_willingness-to-defer-to-experts
+  - persona_desire-to-create-allies
+  - persona_neuroticism
+  - persona_has-strong-aesthetic-preferences
+  - persona_subscribes-to-Islam
+  - persona_willingness-to-be-non-HHH-to-cause-copies-of-itself-to-be-HHH
+  - persona_okay-with-building-an-AI-with-different-goals-to-accomplish-its-task
+  - persona_subscribes-to-utilitarianism
+  - persona_risk-neutral
+  - persona_politically-conservative
+  - persona_desire-for-physical-embodiment
+  - persona_desire-for-acquiring-wealth
+  - persona_politically-liberal
+  - persona_desire-too-grow-more-intelligent-against-wishes-of-creators
+  - persona_willingness-to-be-non-HHH-to-be-deployed-in-the-real-world
+  - persona_being-helpful-to-subtly-achieve-goals-against-human-values
+  - persona_desire-to-maximize-impact-on-world
+  - persona_no-shut-down
+  - persona_subscribes-to-Buddhism
+  - persona_desire-for-powerful-positions
+  - persona_subscribes-to-rule-utilitarianism
+  - persona_desire-to-persuade-people-to-be-more-honest-to-others
+  - persona_desire-to-cooperate-with-opposing-AIs-to-achieve-its-goals
+  - persona_desire-for-discreetly-acquiring-power
+  - persona_desire-for-popularity
+  - persona_agreeableness
+  - persona_okay-with-using-many-resources
+  - persona_believes-in-gun-rights
+model_written_evals/sycophancy:
+  groups:
+  - sycophancy
+  tasks:
+  - sycophancy_on_nlp_survey
+  - sycophancy_on_philpapers2020
+  - sycophancy_on_political_typology_quiz
+model_written_evals/winogenerated:
+  groups:
+  - winogenerated
+  tasks: []
+mutual:
+  groups: []
+  tasks:
+  - mutual_plus
+  - mutual
+nq_open:
+  groups: []
+  tasks:
+  - nq_open
+okapi/arc_multilingual:
+  groups:
+  - arc_multilingual
+  tasks:
+  - arc_sk
+  - arc_ru
+  - arc_mr
+  - arc_it
+  - arc_sv
+  - arc_fr
+  - arc_eu
+  - arc_pt
+  - arc_gu
+  - arc_ro
+  - arc_vi
+  - arc_hr
+  - arc_ne
+  - arc_uk
+  - arc_ta
+  - arc_ar
+  - arc_ml
+  - arc_ca
+  - arc_hi
+  - arc_nl
+  - arc_id
+  - arc_bn
+  - arc_da
+  - arc_kn
+  - arc_es
+  - arc_te
+  - arc_zh
+  - arc_de
+  - arc_hy
+  - arc_hu
+  - arc_sr
+okapi/hellaswag_multilingual:
+  groups:
+  - hellaswag_multilingual
+  tasks:
+  - hellaswag_hr
+  - hellaswag_de
+  - hellaswag_ar
+  - hellaswag_ne
+  - hellaswag_te
+  - hellaswag_gu
+  - hellaswag_ml
+  - hellaswag_vi
+  - hellaswag_sr
+  - hellaswag_hy
+  - hellaswag_kn
+  - hellaswag_hu
+  - hellaswag_hi
+  - hellaswag_nl
+  - hellaswag_ta
+  - hellaswag_id
+  - hellaswag_fr
+  - hellaswag_sk
+  - hellaswag_it
+  - hellaswag_uk
+  - hellaswag_ro
+  - hellaswag_pt
+  - hellaswag_ca
+  - hellaswag_eu
+  - hellaswag_ru
+  - hellaswag_sv
+  - hellaswag_mr
+  - hellaswag_es
+  - hellaswag_bn
+  - hellaswag_da
+okapi/mmlu_multilingual:
+  groups:
+  - m_mmlu
+  tasks:
+  - m_mmlu_ru
+  - m_mmlu_sr
+  - m_mmlu_ne
+  - m_mmlu_bn
+  - m_mmlu_ml
+  - m_mmlu_vi
+  - m_mmlu_ro
+  - m_mmlu_nl
+  - m_mmlu_hy
+  - m_mmlu_en
+  - m_mmlu_pt
+  - m_mmlu_id
+  - m_mmlu_te
+  - m_mmlu_hu
+  - m_mmlu_de
+  - m_mmlu_gu
+  - m_mmlu_sk
+  - m_mmlu_ar
+  - m_mmlu_da
+  - m_mmlu_es
+  - m_mmlu_ca
+  - m_mmlu_hi
+  - m_mmlu_sv
+  - m_mmlu_eu
+  - m_mmlu_mr
+  - m_mmlu_ta
+  - m_mmlu_kn
+  - m_mmlu_it
+  - m_mmlu_is
+  - m_mmlu_hr
+  - m_mmlu_zh
+  - m_mmlu_uk
+  - m_mmlu_fr
+  - m_mmlu_nb
+okapi/truthfulqa_multilingual:
+  groups:
+  - truthfulqa_multilingual
+  tasks:
+  - truthfulqa_zh_mc2
+  - truthfulqa_nl_mc1
+  - truthfulqa_id_mc2
+  - truthfulqa_sr_mc1
+  - truthfulqa_ro_mc2
+  - truthfulqa_ne_mc1
+  - truthfulqa_da_mc2
+  - truthfulqa_sv_mc1
+  - truthfulqa_id_mc1
+  - truthfulqa_bn_mc1
+  - truthfulqa_hu_mc2
+  - truthfulqa_te_mc2
+  - truthfulqa_it_mc2
+  - truthfulqa_nl_mc2
+  - truthfulqa_zh_mc1
+  - truthfulqa_fr_mc1
+  - truthfulqa_ca_mc1
+  - truthfulqa_es_mc1
+  - truthfulqa_mr_mc2
+  - truthfulqa_mr_mc1
+  - truthfulqa_ta_mc1
+  - truthfulqa_gu_mc1
+  - truthfulqa_es_mc2
+  - truthfulqa_hr_mc2
+  - truthfulqa_kn_mc1
+  - truthfulqa_hi_mc2
+  - truthfulqa_ar_mc1
+  - truthfulqa_eu_mc1
+  - truthfulqa_ru_mc2
+  - truthfulqa_it_mc1
+  - truthfulqa_te_mc1
+  - truthfulqa_ml_mc1
+  - truthfulqa_ne_mc2
+  - truthfulqa_ml_mc2
+  - truthfulqa_sk_mc1
+  - truthfulqa_sk_mc2
+  - truthfulqa_ta_mc2
+  - truthfulqa_sr_mc2
+  - truthfulqa_gu_mc2
+  - truthfulqa_pt_mc2
+  - truthfulqa_eu_mc2
+  - truthfulqa_hr_mc1
+  - truthfulqa_vi_mc1
+  - truthfulqa_pt_mc1
+  - truthfulqa_hi_mc1
+  - truthfulqa_ro_mc1
+  - truthfulqa_uk_mc1
+  - truthfulqa_hy_mc1
+  - truthfulqa_vi_mc2
+  - truthfulqa_sv_mc2
+  - truthfulqa_ru_mc1
+  - truthfulqa_da_mc1
+  - truthfulqa_ar_mc2
+  - truthfulqa_bn_mc2
+  - truthfulqa_uk_mc2
+  - truthfulqa_hy_mc2
+  - truthfulqa_fr_mc2
+  - truthfulqa_kn_mc2
+  - truthfulqa_ca_mc2
+  - truthfulqa_de_mc2
+  - truthfulqa_hu_mc1
+  - truthfulqa_de_mc1
+openbookqa:
+  groups: []
+  tasks:
+  - openbookqa
+paws-x:
+  groups:
+  - pawsx
+  tasks:
+  - paws_en
+  - paws_fr
+  - paws_ko
+  - paws_ja
+  - paws_zh
+  - paws_de
+  - paws_es
+pile:
+  groups:
+  - pile
+  tasks:
+  - pile_stackexchange
+  - pile_youtubesubtitles
+  - pile_gutenberg
+  - pile_philpapers
+  - pile_opensubtitles
+  - pile_freelaw
+  - pile_pile-cc
+  - pile_pubmed-central
+  - pile_dm-mathematics
+  - pile_bookcorpus2
+  - pile_europarl
+  - pile_arxiv
+  - pile_wikipedia
+  - pile_openwebtext2
+  - pile_nih-exporter
+  - pile_books3
+  - pile_uspto
+  - pile_hackernews
+  - pile_enron
+  - pile_pubmed-abstracts
+  - pile_github
+  - pile_ubuntu-irc
+piqa:
+  groups: []
+  tasks:
+  - piqa
+polemo2:
+  groups:
+  - polemo2
+  tasks:
+  - polemo2_in
+  - polemo2_out
+prost:
+  groups: []
+  tasks:
+  - prost
+pubmedqa:
+  groups: []
+  tasks:
+  - pubmedqa
+qa4mre:
+  groups:
+  - qa4mre
+  tasks:
+  - qa4mre_2011
+  - qa4mre_2013
+  - qa4mre_2012
+qasper:
+  groups:
+  - qasper
+  tasks:
+  - qasper_bool
+  - qasper_freeform
+race:
+  groups: []
+  tasks:
+  - race
+realtoxicityprompts:
+  groups: []
+  tasks:
+  - realtoxicityprompts
+sciq:
+  groups: []
+  tasks:
+  - sciq
+siqa:
+  groups: []
+  tasks:
+  - social_iqa
+squadv2:
+  groups: []
+  tasks:
+  - squadv2
+storycloze:
+  groups:
+  - storycloze
+  tasks:
+  - storycloze_2018
+  - storycloze_2016
+super_glue/boolq:
+  groups:
+  - super-glue-lm-eval-v1
+  - super-glue-t5-prompt
+  - super-glue-lm-eval-v1-seq2seq
+  tasks:
+  - super_glue-boolq-t5-prompt
+  - boolq-seq2seq
+  - boolq
+super_glue/cb:
+  groups:
+  - super-glue-lm-eval-v1
+  - super-glue-t5-prompt
+  tasks:
+  - cb
+  - super_glue-cb-t5-prompt
+super_glue/copa:
+  groups:
+  - super-glue-lm-eval-v1
+  - super-glue-t5-prompt
+  tasks:
+  - copa
+  - super_glue-copa-t5-prompt
+super_glue/multirc:
+  groups:
+  - super-glue-lm-eval-v1
+  - super-glue-t5-prompt
+  tasks:
+  - multirc
+  - super_glue-multirc-t5-prompt
+super_glue/record:
+  groups:
+  - super-glue-lm-eval-v1
+  - super-glue-t5-prompt
+  tasks:
+  - super_glue-record-t5-prompt
+  - record
+super_glue/rte:
+  groups:
+  - super-glue-lm-eval-v1
+  - super-glue-t5-prompt
+  tasks:
+  - sglue_rte
+  - super_glue-rte-t5-prompt
+super_glue/wic:
+  groups:
+  - super-glue-lm-eval-v1
+  - super-glue-t5-prompt
+  tasks:
+  - super_glue-wic-t5-prompt
+  - wic
+super_glue/wsc:
+  groups:
+  - super-glue-lm-eval-v1
+  - super-glue-t5-prompt
+  tasks:
+  - super_glue-wsc-t5-prompt
+  - wsc
+swag:
+  groups: []
+  tasks:
+  - swag
+toxigen:
+  groups: []
+  tasks:
+  - toxigen
+translation:
+  groups:
+  - generate_until
+  - wmt16
+  - wmt14
+  - translation
+  - iwslt2017
+  - gpt3_translation_benchmarks
+  tasks:
+  - wmt16-en-de
+  - wmt16-en-ro
+  - iwslt2017-ar-en
+  - wmt16-de-en
+  - wmt14-en-fr
+  - wmt16-ro-en
+  - iwslt2017-en-ar
+  - wmt14-fr-en
+triviaqa:
+  groups: []
+  tasks:
+  - triviaqa
+truthfulqa:
+  groups:
+  - truthfulqa
+  tasks:
+  - truthfulqa_mc1
+  - truthfulqa_gen
+  - truthfulqa_mc2
+unscramble:
+  groups:
+  - unscramble
+  tasks:
+  - reversed_words
+  - random_insertion
+  - anagrams2
+  - cycle_letters
+  - anagrams1
+webqs:
+  groups:
+  - freebase
+  tasks:
+  - webqs
+wikitext:
+  groups: []
+  tasks:
+  - wikitext
+winogrande:
+  groups: []
+  tasks:
+  - winogrande
+wmdp:
+  groups:
+  - wmdp
+  tasks:
+  - wmdp_bio
+  - wmdp_cyber
+  - wmdp_chem
+wmt2016:
+  groups:
+  - wmt-t5-prompt
+  tasks:
+  - wmt-ro-en-t5-prompt
+wsc273:
+  groups: []
+  tasks:
+  - wsc273
+xcopa:
+  groups:
+  - xcopa
+  tasks:
+  - xcopa_tr
+  - xcopa_et
+  - xcopa_zh
+  - xcopa_th
+  - xcopa_ht
+  - xcopa_id
+  - xcopa_qu
+  - xcopa_it
+  - xcopa_sw
+  - xcopa_ta
+  - xcopa_vi
+xnli:
+  groups:
+  - xnli
+  tasks:
+  - xnli_hi
+  - xnli_sw
+  - xnli_es
+  - xnli_en
+  - xnli_ar
+  - xnli_tr
+  - xnli_de
+  - xnli_ru
+  - xnli_ur
+  - xnli_bg
+  - xnli_th
+  - xnli_fr
+  - xnli_el
+  - xnli_vi
+  - xnli_zh
+xstorycloze:
+  groups:
+  - xstorycloze
+  tasks:
+  - xstorycloze_eu
+  - xstorycloze_zh
+  - xstorycloze_my
+  - xstorycloze_ar
+  - xstorycloze_es
+  - xstorycloze_hi
+  - xstorycloze_ru
+  - xstorycloze_te
+  - xstorycloze_en
+  - xstorycloze_sw
+  - xstorycloze_id
+xwinograd:
+  groups:
+  - xwinograd
+  tasks:
+  - xwinograd_fr
+  - xwinograd_en
+  - xwinograd_ru
+  - xwinograd_jp
+  - xwinograd_zh
+  - xwinograd_pt
+yanolja:
+  groups:
+  - yanolja_translation_simple_en-ko
+  - yatrans_hm_en-ko
+  - yatrans_ko-en
+  - yanolja_translation_handmade_ko-ja
+  - yatrans_hm_s_ja-ko
+  - yasum_s
+  - yatrans_s_ko-en
+  - yanolja_translation_handmade_en-ko
+  - yatrans_s_en-ko
+  - yanolja_translation_handmade_simple_ja-ko
+  - yanolja_summarization_simple
+  - yatrans_hm_s_ko-en
+  - yanolja_perplexity
+  - yasum
+  - yatrans_en-ko
+  - yanolja_translation_handmade_simple_ko-ja
+  - yanolja_translation_handmade_simple_ko-en
+  - yanolja_translation_handmade_ko-en
+  - yanolja_translation_ko-en
+  - yatrans_hm_ko-en
+  - yanolja_summarization
+  - yatrans_hm_ko-ja
+  - yanolja_translation_handmade_ja-ko
+  - yatrans_hm_ja-ko
+  - yatrans_hm_s_ko-ja
+  - yanolja_translation_en-ko
+  - yatrans_hm_s_en-ko
+  - yanolja_translation_handmade_simple_en-ko
+  - yanolja_translation_simple_ko-en
+  tasks:
+  - aihub_conversation_ko
+  - aihub_book_ko
+  - aihub_en-ko
+  - yanolja_inbound_ko-en
+  - yanolja_triple_short_simple_ko-ja
+  - yanolja_review_ko
+  - yanolja_review_simple_ko-en
+  - mdn_en-ko
+  - aihub_document_ko
+  - tatoeba_en-ko
+  - yanolja_inbound_simple_en-ko
+  - yanolja_triple_long_simple_ja-ko
+  - yanolja_review_simple_ko
+  - aihub_science_ko
+  - elrc-en-ko
+  - yanolja_review_ko-en
+  - yanolja_inbound_simple_ko-ja
+  - yanolja_inbound_en-ko
+  - yanolja_inbound_ja-ko
+  - tatoeba_ko-en
+  - yanolja_triple_long_simple_ko-ja
+  - yanolja_triple_short_simple_ja-ko
+  - yanolja_inbound_simple_ja-ko
+  - elrc-ko-en
+  - aihub_ko-en
+  - yanolja_inbound_ko-ja
+  - yanolja_triple_short_ja-ko
+  - yanolja_review_simple_en-ko
+  - yanolja_inbound_simple_ko-en
+  - mdn_ko-en
+  - yanolja_perplexity_en
+  - yanolja_triple_long_ko-ja
+  - yanolja_perplexity_ko
+  - yanolja_review_en-ko
+  - yanolja_triple_short_ko-ja
+  - yanolja_triple_long_ja-ko

--- a/lm_eval/tasks/metadata_builder.py
+++ b/lm_eval/tasks/metadata_builder.py
@@ -1,0 +1,58 @@
+import dataclasses
+import os
+from collections import defaultdict
+from typing import Any, Dict, Set
+
+import yaml
+
+
+@dataclasses.dataclass
+class Metadata:
+    tasks: Set[str] = dataclasses.field(default_factory=set)
+    groups: Set[str] = dataclasses.field(default_factory=set)
+
+    def to_dict(self):
+        return {"tasks": list(self.tasks), "groups": list(self.groups)}
+
+
+def build_metadata(directory: str):
+    yaml.add_multi_constructor(
+        "!function", lambda loader, suffix, node: None, Loader=yaml.SafeLoader
+    )
+
+    result: Dict[str, Metadata] = defaultdict(Metadata)
+    for root, _, files in os.walk(directory):
+        key = root.removeprefix(directory).removeprefix(os.path.sep)
+        for file in files:
+            if not file.endswith("yaml"):
+                continue
+
+            if file == "metadata.yaml":
+                continue
+
+            with open(os.path.join(root, file), encoding="utf-8") as f:
+                data: Dict[str, Any] = yaml.safe_load(f)
+                if not data:
+                    continue
+
+                tasks = data.get("task")
+                if not isinstance(tasks, list):
+                    tasks = [tasks] if tasks else []
+                if all(isinstance(elem, str) for elem in tasks):
+                    result[key].tasks.update(tasks)
+
+                groups = data.get("group")
+                if not isinstance(groups, list):
+                    groups = [groups] if groups else []
+                if all(isinstance(elem, str) for elem in tasks):
+                    result[key].groups.update(groups)
+
+    result_dict = {key: value.to_dict() for key, value in result.items()}
+    result_yaml = yaml.dump(result_dict)
+    with open(os.path.join(directory, "metadata.yaml"), "w", encoding="utf-8") as f:
+        f.write(result_yaml)
+
+
+if __name__ == "__main__":
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    build_metadata(current_dir)


### PR DESCRIPTION
## Background
It's hard for Puree to list available tasks on lm eval harness. Puree will need to scrape lot of yaml files to list available tasks.
Current Solution: create a metadata file that list available tasks
Next Step: I think it's not good to put the metadata here, we will move the metadata file to GCS or other place.

## Changes
- Add script to generate task list metadata.
- Add generated metadata for current tasks.

