### PR TITLE
Add a Translation Task as Multiple Choice

### DIFF
--- a/lm_eval/tasks/yanolja/translation_as_multiple_choice_en-ko.yaml
+++ b/lm_eval/tasks/yanolja/translation_as_multiple_choice_en-ko.yaml
@@ -10,7 +10,7 @@ dataset_kwargs:
 output_type: multiple_choice
 training_split:
 validation_split: 
-test_split: 
+test_split: train
 
 doc_to_text: !function utils.translation_mc_get_prompt_en_ko
 doc_to_target: !function utils.translation_mc_get_answer_idx
@@ -20,10 +20,8 @@ metric_list:
   - metric: acc
     aggregation: mean
     higher_is_better: True
-  - metric: f1
-    aggregation: !function utils.macro_f1_score
-    average: macro
-    hf_evaluate: true
+  - metric: acc_norm
+    aggregation: mean
     higher_is_better: True
 
 metadata:

--- a/lm_eval/tasks/yanolja/translation_as_multiple_choice_en-ko.yaml
+++ b/lm_eval/tasks/yanolja/translation_as_multiple_choice_en-ko.yaml
@@ -13,7 +13,7 @@ validation_split:
 test_split: train
 
 doc_to_text: !function utils.translation_mc_get_prompt_en_ko
-doc_to_target: !function utils.translation_mc_get_answer_idx
+doc_to_target: !function utils.translation_mc_get_target
 doc_to_choice: !function utils.translation_mc_get_choices
 
 metric_list:

--- a/lm_eval/tasks/yanolja/translation_as_multiple_choice_en-ko.yaml
+++ b/lm_eval/tasks/yanolja/translation_as_multiple_choice_en-ko.yaml
@@ -1,0 +1,30 @@
+group: 
+  - yanolja
+  - yanolja_translation_multiple_choice
+task: translation_aihub_en-ko_multiple_choice
+dataset_name: translation_aihub_en-ko_multiple_choice
+dataset_path: json
+dataset_kwargs:
+  data_files: /data/shared/datasets/translation_evaluation/aihub_translation_mtpe_filtered_valid_en-ko.jsonl
+
+output_type: multiple_choice
+training_split:
+validation_split: 
+test_split: 
+
+doc_to_text: !function utils.translation_mc_get_prompt_en_ko
+doc_to_target: !function utils.translation_mc_get_answer_idx
+doc_to_choice: !function utils.translation_mc_get_choices
+
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: True
+  - metric: f1
+    aggregation: !function utils.macro_f1_score
+    average: macro
+    hf_evaluate: true
+    higher_is_better: True
+
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/yanolja/translation_as_multiple_choice_ko-en.yaml
+++ b/lm_eval/tasks/yanolja/translation_as_multiple_choice_ko-en.yaml
@@ -1,0 +1,30 @@
+group: 
+  - yanolja
+  - yanolja_translation_multiple_choice
+task: translation_aihub_ko-en_multiple_choice
+dataset_name: translation_aihub_ko-en_multiple_choice
+dataset_path: json
+dataset_kwargs:
+  data_files: /data/shared/datasets/translation_evaluation/aihub_translation_mtpe_filtered_valid_ko-en.jsonl
+
+output_type: multiple_choice
+training_split:
+validation_split: 
+test_split: 
+
+doc_to_text: !function utils.translation_mc_get_prompt_ko_en
+doc_to_target: !function utils.translation_mc_get_answer_idx
+doc_to_choice: !function utils.translation_mc_get_choices
+
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: True
+  - metric: f1
+    aggregation: !function utils.macro_f1_score
+    average: macro
+    hf_evaluate: true
+    higher_is_better: True
+
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/yanolja/translation_as_multiple_choice_ko-en.yaml
+++ b/lm_eval/tasks/yanolja/translation_as_multiple_choice_ko-en.yaml
@@ -10,7 +10,7 @@ dataset_kwargs:
 output_type: multiple_choice
 training_split:
 validation_split: 
-test_split: 
+test_split: train
 
 doc_to_text: !function utils.translation_mc_get_prompt_ko_en
 doc_to_target: !function utils.translation_mc_get_answer_idx
@@ -20,10 +20,8 @@ metric_list:
   - metric: acc
     aggregation: mean
     higher_is_better: True
-  - metric: f1
-    aggregation: !function utils.macro_f1_score
-    average: macro
-    hf_evaluate: true
+  - metric: acc_norm
+    aggregation: mean
     higher_is_better: True
 
 metadata:

--- a/lm_eval/tasks/yanolja/translation_as_multiple_choice_ko-en.yaml
+++ b/lm_eval/tasks/yanolja/translation_as_multiple_choice_ko-en.yaml
@@ -13,7 +13,7 @@ validation_split:
 test_split: train
 
 doc_to_text: !function utils.translation_mc_get_prompt_ko_en
-doc_to_target: !function utils.translation_mc_get_answer_idx
+doc_to_target: !function utils.translation_mc_get_target
 doc_to_choice: !function utils.translation_mc_get_choices
 
 metric_list:

--- a/lm_eval/tasks/yanolja/utils.py
+++ b/lm_eval/tasks/yanolja/utils.py
@@ -6,7 +6,7 @@ def translation_mc_get_prompt_en_ko(doc: dict) -> str:
     return f"""You are a helpful AI assistant that is translating English to Korean. The English text is given below. Please start the translated text in Korean.
     English: {doc["segments"]["sourceText"]}"""
 
-def translation_mc_get_answer_idx(doc: dict) -> str:
+def translation_mc_get_target(doc: dict) -> str:
     return f"""{doc["segments"]["targetText"]}"""
 
 def translation_mc_get_choices(doc: dict) -> str:

--- a/lm_eval/tasks/yanolja/utils.py
+++ b/lm_eval/tasks/yanolja/utils.py
@@ -1,10 +1,10 @@
 def translation_mc_get_prompt_ko_en(doc: dict) -> str:
     return f"""You are a helpful AI assistant that is translating Korean to English. The Korean text is given below. Please start the translated text in English.
-    Korean: {dict["segments"]["source"]}"""
+    Korean: {doc["segments"]["sourceText"]}"""
 
 def translation_mc_get_prompt_en_ko(doc: dict) -> str:
     return f"""You are a helpful AI assistant that is translating English to Korean. The English text is given below. Please start the translated text in Korean.
-    English: {dict["segments"]["source"]}"""
+    English: {doc["segments"]["sourceText"]}"""
 
 def translation_mc_get_answer_idx(doc: dict) -> str:
     return f"""{doc["segments"]["targetText"]}"""

--- a/lm_eval/tasks/yanolja/utils.py
+++ b/lm_eval/tasks/yanolja/utils.py
@@ -1,0 +1,13 @@
+def translation_mc_get_prompt_ko_en(doc: dict) -> str:
+    return f"""You are a helpful AI assistant that is translating Korean to English. The Korean text is given below. Please start the translated text in English.
+    Korean: {dict["segments"]["source"]}"""
+
+def translation_mc_get_prompt_en_ko(doc: dict) -> str:
+    return f"""You are a helpful AI assistant that is translating English to Korean. The English text is given below. Please start the translated text in Korean.
+    English: {dict["segments"]["source"]}"""
+
+def translation_mc_get_answer_idx(doc: dict) -> str:
+    return f"""{doc["segments"]["targetText"]}"""
+
+def translation_mc_get_choices(doc: dict) -> str:
+    return [f"""{doc["segments"]["mtText"]}""", f"""{doc["segments"]["targetText"]}"""]


### PR DESCRIPTION
- Dataset: `/data/shared/datasets/translation_evaluation/aihub_translation_mtpe_filtered_valid_ko-en.jsonl`
- Given `sourceText`, a model is tasked to generate `mtText` or `targetText`. If the model assigns a higher likelihood on `targetText` (gold translation), it is treated as correct, such that we could measure the `acc` (accuracy).

An example entry is like
```json
"sourceText": "한국을 바라보는 미국 드라마와 영화 업계의 반응이 그리 나쁘지 않은 것도 호재다.",
"mtText": "Another positive factor is that the response of the American drama and film industry to Korea is not so bad.",
"targetText": "Another positive factor is that the response of the U.S. drama and film industry regarding Korea is not so bad.",       
```

Question: Is it the right way to merge this PR into the main? 